### PR TITLE
Correction after dev review

### DIFF
--- a/source/content/glossar/bibliothek/dcat-ap-ch.rst
+++ b/source/content/glossar/bibliothek/dcat-ap-ch.rst
@@ -185,189 +185,149 @@ Translateable elements are marked as such under usage notes.
 The conformance note-cell contains information about the DCAT-AP-CH conformance.
 
 .. list-table:: Classes of DCAT-AP-CH
-    :widths: 20 20 30 30
+    :widths: 20 20 30
     :header-rows: 1
     :stub-columns: 1
 
     * - class
       - URI
       - usage notes
-      - conformance note
     * - :ref:`Catalog <dcat-ap-ch-catalog>`
       - dcat:Catalog
       - **mandatory**
-      - not all DCAT-AP-CH properties are implemented
     * - :ref:`Dataset <dcat-ap-ch-dataset>`
       - dcat:Dataset
       - **mandatory**
-      -
     * - :ref:`Distribution <dcat-ap-ch-distribution>`
       - dcat:Distribution
       - **mandatory**
-      -
 
 .. list-table:: Properties of dcat:Catalog
-    :widths: 20 20 30 30
+    :widths: 20 20 30
     :header-rows: 1
     :stub-columns: 1
 
     * - property
       - URI
       - usage notes
-      - conformance note
     * - :ref:`dataset <dcat-catalog-dataset>`
       - dcat:dataset
       - **mandatory**
-      -
 
 .. list-table:: Properties of dcat:Dataset
-    :widths: 20 20 30 30
+    :widths: 20 20 30
     :header-rows: 1
     :stub-columns: 1
 
     * - property
       - URI
       - usage notes
-      - conformance note
     * - :ref:`title <dcat-dataset-title>`
       - dct:title
       - **mandatory**, multilingual
-      -
     * - :ref:`description <dcat-dataset-description>`
       - dct:description
       - **mandatory**, multilingual
-      -
     * - :ref:`publisher <dcat-dataset-publisher>`
       - dct:publisher
       - **mandatory**, **CHANGED rule**
-      - does not conform to DCAT-AP-CH
     * - :ref:`contact point <dcat-dataset-contact-point>`
       - dcat:contactPoint
       - **mandatory**
-      -
     * - :ref:`identifier <dcat-dataset-identifier>`
       - dct:identifier
       - **mandatory**
-      -
     * - :ref:`distribution <dcat-dataset-distribution>`
       - dcat:distribution
       - **mandatory**
-      -
     * - :ref:`issued <dcat-dataset-issued>`
       - dct:issued
       - conditional
-      -
     * - :ref:`modified <dcat-dataset-modified>`
       - dct:modified
       - conditional
-      -
     * - :ref:`theme <dcat-dataset-theme>`
       - dcat:theme
       - conditional
-      -
     * - :ref:`landing page <dcat-dataset-landing-page>`
       - dcat:landingPage
       - conditional
-      -
     * - :ref:`language <dcat-dataset-language>`
       - dct:language
       - conditional
-      -
     * - :ref:`keyword <dcat-dataset-keyword>`
       - dcat:keyword
       - optional
-      -
     * - :ref:`spatial <dcat-dataset-spatial>`
       - dct:spatial
       - optional
-      -
     * - :ref:`coverage <dcat-dataset-coverage>`
       - dct:coverage
       - optional
-      -
     * - :ref:`temporal <dcat-dataset-temporal>`
       - dct:temporal
       - optional
-      -
     * - :ref:`accrual periodicty <dcat-dataset-accrual-periodicity>`
       - dct:accrualPeriodicity
       - optional
-      -
     * - :ref:`coverage <dcat-dataset-relation>`
       - dct:relation
       - optional
-      -
     * - :ref:`see alsos <dcat-dataset-see-alsos>`
       - rdfs:seeAlsos
       - optional
-      -
 
 
 .. list-table:: Properties of dcat:Distribution
-    :widths: 20 20 30 30
+    :widths: 20 20 30
     :header-rows: 1
     :stub-columns: 1
 
     * - property
       - URI
       - usage notes
-      - conformance note
     * - :ref:`issued <dcat-distribution-issued>`
       - dct:issued
       - **mandatory**
-      -
     * - :ref:`access url <dcat-distribution-access-url>`
       - dcat:accessURL
       - **mandatory**
-      -
     * - :ref:`rights <dcat-distribution-rights>`
       - dct:rights
       - **mandatory**
-      - does not conform to DCAT-AP-CH
     * - :ref:`title <dcat-distribution-title>`
       - dct:title
       - conditional
-      -
     * - :ref:`description <dcat-distribution-description>`
       - dct:description
       - conditional
-      -
     * - :ref:`byte size <dcat-distribution-byte-size>`
       - dct:byteSize
       - conditional
-      -
     * - :ref:`media type <dcat-distribution-media-type>`
       - dct:mediaType
       - conditional
-      -
     * - :ref:`format <dcat-distribution-format>`
       - dct:format
       - conditional
-      -
     * - :ref:`language <dcat-distribution-language>`
       - dct:language
       - conditional
-      -
     * - :ref:`modified <dcat-distribution-modified>`
       - dct:modified
       - conditional
-      -
     * - :ref:`license <dcat-distribution-license>`
       - dcat:license
       - optional
-      - does not conform to DCAT-AP
     * - :ref:`identifier <dcat-distribution-identifier>`
       - dct:identifier
       - optional
-      -
     * - :ref:`download url <dcat-distribution-download-url>`
       - dcat:downloadURL
       - optional
-      -
     * - :ref:`coverage <dcat-distribution-coverage>`
       - dct:coverage
       - optional
-      -
 
 .. _dcat-ap-ch-catalog:
 

--- a/source/content/glossar/bibliothek/dcat-ap-ch.rst
+++ b/source/content/glossar/bibliothek/dcat-ap-ch.rst
@@ -49,7 +49,7 @@ DCAT-AP-CH Standard Overview
 RDF-File Structure & Example
 ------------------------------
 
-Your datacatalog must follow the DCAT-AP-CH standard.
+Your data catalog must follow the DCAT-AP-CH standard.
 It consists of the following 4 Classes:
 
 - the catalog
@@ -58,8 +58,7 @@ It consists of the following 4 Classes:
 - the distributions
 
 These classes relate to each other as described below.
-All examples will be provided in both ``turtle`` and ``rdf``. ``turtle`` is generally
-easier to read and understand. ``rdf`` is used for the actual import of the data
+All examples will be provided in both ``turtle`` and ``rdf``. ``rdf`` is used for the actual import of the data.
 You can use a converter to convert between these two formats:
 https://www.easyrdf.org/converter
 
@@ -104,11 +103,11 @@ It is important to provide URIs for each of the classes in your catalog.
 
         </rdf:RDF>
 
-The example catalogs above just show the classes. But each of those classes has also further properties.
-Here you can find an overview of those properties and which of these you must provide:
+The example catalogs above show the classes without any further properties.
+Here you can find an overview of all possible properties and which of these you must provide.
 
 - ``mandatory`` means you MUST provide them
-- ``contidional`` means you must provide them under certain conditions
+- ``conditional`` means you must provide them under certain conditions
 - ``optional`` means you may provide them
 
 Example for Download
@@ -123,13 +122,13 @@ Namespaces
 ------------
 
 All classes and properties have definitions that are accessible with an URI.
-Usually this URIs are provided in the header of the datacatalog and receive an alias there,
+Usually these URIs are provided in the header of the data catalog and receive an alias there,
 so that they can be easier referenced in the rest of the catalog:
 A ``dcat:Dataset`` really means ``http://www.w3.org/ns/dcat#Dataset``. But since you don't want
 to write that throughout the document: a namespace is defined by ``@prefix dcat: <http://www.w3.org/ns/dcat#> .`` in ``turtle``
 or ``xmlns:dcat="http://www.w3.org/ns/dcat#"`` in ``RDF``
 
-These here are the namespaces that are used in DCAT-AP-CH:
+These are the namespaces that are used in DCAT-AP-CH:
 
 .. code-block:: turtle
     :caption: DCAT-AP-CH namespaces in turtle
@@ -164,9 +163,15 @@ These here are the namespaces that are used in DCAT-AP-CH:
 Internationalisation
 --------------------
 
-The DCAT-AP for Switzerland Standard expects that text elements of the
-datasets and their distributions be translated in the following four
-languages: \* French (fr) \* German (de) \* Italian (it) \* English (en).
+The DCAT-AP-CH Standard expects that text elements of
+datasets and their distributions are translated in the following four
+languages:
+
+- French (fr)
+- German (de)
+- Italian (it)
+- English (en)
+
 Examples are provided for how to translate those
 elements for all relevant properties.
 
@@ -175,9 +180,9 @@ elements for all relevant properties.
 Overview
 ---------
 
-Below you find a list of classes that you need to implement in you catalog.
-Translateable elements have been marked. Also DCAT-AP-CH conformance has been
-marked.
+Below you find a list of classes that you need to implement in your catalog.
+Translateable elements are marked as such under usage notes.
+The conformance note-cell contains information about the DCAT-AP-CH conformance.
 
 .. list-table:: Classes of DCAT-AP-CH
     :widths: 20 20 30 30
@@ -479,12 +484,12 @@ dct:description (DCAT)
     .. include:: dcat-definitions/dataset-description.rst
 
 .. toggle-header::
-    :header: Property ```dct:description`` of ``dcat:Dataset`` using Markdown in Turtle
+    :header: Property ``dct:description`` of ``dcat:Dataset`` using Markdown in Turtle
 
     .. include:: dcat-examples/dataset-description-ttl.rst
 
 .. toggle-header::
-    :header: Property ```dct:description`` of ``dcat:Dataset`` using Markdown in RDF
+    :header: Property ``dct:description`` of ``dcat:Dataset`` using Markdown in RDF
 
     .. include:: dcat-examples/dataset-description-rdf.rst
 
@@ -498,12 +503,12 @@ dct:publisher (DCAT)
     .. include:: dcat-definitions/dataset-publisher.rst
 
 .. toggle-header::
-    :header: CURRENT Property ``dct:publisher`` of ``dcat:Dataset`` in Turtle
+    :header: Property ``dct:publisher`` of ``dcat:Dataset`` in Turtle
 
     .. include:: dcat-examples/dataset-publisher-ttl.rst
 
 .. toggle-header::
-    :header: CURRENT Property ``dct:publisher`` of ``dcat:Dataset`` in RDF
+    :header: Property ``dct:publisher`` of ``dcat:Dataset`` in RDF
 
     .. include:: dcat-examples/dataset-publisher-rdf.rst
 
@@ -632,24 +637,14 @@ dcat:landingPage (DCAT)
     .. include:: dcat-definitions/dataset-landing-page.rst
 
 .. toggle-header::
-    :header: CURRENT Property ``dcat:landingPage`` of ``dcat:Dataset`` in Turtle
+    :header: Property ``dcat:landingPage`` of ``dcat:Dataset`` in Turtle
 
     .. include:: dcat-examples/dataset-landing-page-ttl.rst
 
 .. toggle-header::
-    :header: CURRENT Property ``dcat:landingPage`` of ``dcat:Dataset`` in RDF
+    :header: Property ``dcat:landingPage`` of ``dcat:Dataset`` in RDF
 
     .. include:: dcat-examples/dataset-landing-page-rdf.rst
-
-.. toggle-header::
-    :header: NEW Property ``dcat:landingPage`` of ``dcat:Dataset`` in Turtle
-
-    .. include:: dcat-examples/dataset-landing-page-new-ttl.rst
-
-.. toggle-header::
-    :header: NEW Property ``dcat:landingPage`` of ``dcat:Dataset`` in RDF
-
-    .. include:: dcat-examples/dataset-landing-page-new-rdf.rst
 
 .. _dcat-dataset-relation:
 
@@ -710,7 +705,7 @@ dct:spatial (DCAT)
 
 .. _dcat-dataset-coverage:
 
-dct:relation (DCAT)
+dct:coverage (DCAT)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. container:: Mapping
@@ -748,26 +743,26 @@ dct:temporal (DCAT)
 
 .. _dcat-dataset-accrual-periodicity:
 
-dct:accrual-periodicty (DCAT)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+dct:accrual-periodicity (DCAT)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. container:: Mapping
 
     .. include:: dcat-definitions/dataset-accrual-periodicity.rst
 
 .. toggle-header::
-    :header: Property ``dct:accrualPeriodicty`` of ``dcat:Dataset`` in Turtle
+    :header: Property ``dct:accrualPeriodicity`` of ``dcat:Dataset`` in Turtle
 
     .. include:: dcat-examples/dataset-accrual-periodicity-ttl.rst
 
 .. toggle-header::
-    :header: Property ``dct:accrualPeriodicty`` of ``dcat:Dataset`` in RDF
+    :header: Property ``dct:accrualPeriodicity`` of ``dcat:Dataset`` in RDF
 
     .. include:: dcat-examples/dataset-accrual-periodicity-rdf.rst
 
 .. _dcat-dataset-see-alsos:
 
-dcat:see-alsos (DCAT)
+dcat:seeAlsos (DCAT)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. container:: Mapping
@@ -818,12 +813,12 @@ dcat:accessURL (DCAT)
    .. include:: dcat-definitions/distribution-access-url.rst
 
 .. toggle-header::
-    :header: Property ``dcat:accessURL`` of ``dcat:Distribution`` in RDF
+    :header: Property ``dcat:accessURL`` of ``dcat:Distribution`` in Turtle
 
     .. include:: dcat-examples/distribution-access-url-ttl.rst
 
 .. toggle-header::
-    :header: Property ``dcat:accessURL`` of ``dcat:Distribution`` in Turtle
+    :header: Property ``dcat:accessURL`` of ``dcat:Distribution`` in RDF
 
     .. include:: dcat-examples/distribution-access-url-rdf.rst
 
@@ -990,12 +985,12 @@ dct:description (DCAT)
    .. include:: dcat-definitions/distribution-description.rst
 
 .. toggle-header::
-    :header: Property ```dct:description`` of ``dcat:Distribution`` in Turtle
+    :header: Property ``dct:description`` of ``dcat:Distribution`` in Turtle
 
     .. include:: dcat-examples/distribution-description-ttl.rst
 
 .. toggle-header::
-    :header: Property ```dct:description`` of ``dcat:Distribution`` in RDF
+    :header: Property ``dct:description`` of ``dcat:Distribution`` in RDF
 
     .. include:: dcat-examples/distribution-description-rdf.rst
 

--- a/source/content/glossar/bibliothek/dcat-ap-ch.rst
+++ b/source/content/glossar/bibliothek/dcat-ap-ch.rst
@@ -266,7 +266,7 @@ Translateable elements are marked as such under usage notes.
     * - :ref:`temporal <dcat-dataset-temporal>`
       - dct:temporal
       - optional
-    * - :ref:`accrual periodicty <dcat-dataset-accrual-periodicity>`
+    * - :ref:`accrual periodicity <dcat-dataset-accrual-periodicity>`
       - dct:accrualPeriodicity
       - optional
     * - :ref:`coverage <dcat-dataset-relation>`

--- a/source/content/glossar/bibliothek/dcat-ap-ch.rst
+++ b/source/content/glossar/bibliothek/dcat-ap-ch.rst
@@ -182,7 +182,6 @@ Overview
 
 Below you find a list of classes that you need to implement in your catalog.
 Translateable elements are marked as such under usage notes.
-The conformance note-cell contains information about the DCAT-AP-CH conformance.
 
 .. list-table:: Classes of DCAT-AP-CH
     :widths: 20 20 30
@@ -230,7 +229,7 @@ The conformance note-cell contains information about the DCAT-AP-CH conformance.
       - **mandatory**, multilingual
     * - :ref:`publisher <dcat-dataset-publisher>`
       - dct:publisher
-      - **mandatory**, **CHANGED rule**
+      - **mandatory**
     * - :ref:`contact point <dcat-dataset-contact-point>`
       - dcat:contactPoint
       - **mandatory**
@@ -257,7 +256,7 @@ The conformance note-cell contains information about the DCAT-AP-CH conformance.
       - conditional
     * - :ref:`keyword <dcat-dataset-keyword>`
       - dcat:keyword
-      - optional
+      - optional, multilingual
     * - :ref:`spatial <dcat-dataset-spatial>`
       - dct:spatial
       - optional
@@ -297,10 +296,10 @@ The conformance note-cell contains information about the DCAT-AP-CH conformance.
       - **mandatory**
     * - :ref:`title <dcat-distribution-title>`
       - dct:title
-      - conditional
+      - conditional, multilingual
     * - :ref:`description <dcat-distribution-description>`
       - dct:description
-      - conditional
+      - conditional, multilingual
     * - :ref:`byte size <dcat-distribution-byte-size>`
       - dct:byteSize
       - conditional

--- a/source/content/glossar/bibliothek/dcat-definitions/catalog-class.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/catalog-class.rst
@@ -1,5 +1,5 @@
 :DCAT URI: dcat:Catalog
 :Requirement Level: mandatory
 :Cardinality: 1..1
-:Description: Catalog with datasets, usually a calatog endpoint
-:Usage Notes: if possible provide a URI, where the catalog can be reached
+:Description: Catalog with datasets, usually a catalog endpoint
+:Usage Notes: If possible provide a URI, where the catalog can be accessed

--- a/source/content/glossar/bibliothek/dcat-definitions/catalog-datasets.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/catalog-datasets.rst
@@ -3,5 +3,5 @@
 :Value: dcat:Dataset
 :Requirement Level: mandatory
 :Cardinality: 1..n
-:Description: Datasets that are included in the catalogue
+:Description: Datasets that are included in the catalog
 :Usage Notes: Provide at least one dataset per catalog

--- a/source/content/glossar/bibliothek/dcat-definitions/catalog-datasets.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/catalog-datasets.rst
@@ -1,5 +1,4 @@
 :DCAT URI: dcat:dataset
-:Domain: dcat:Catalog
 :Value: dcat:Dataset
 :Requirement Level: mandatory
 :Cardinality: 1..n

--- a/source/content/glossar/bibliothek/dcat-definitions/catalog-datasets.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/catalog-datasets.rst
@@ -1,4 +1,5 @@
 :DCAT URI: dcat:dataset
+:Domain: dcat:Catalog
 :Value: dcat:Dataset
 :Requirement Level: mandatory
 :Cardinality: 1..n

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-accrual-periodicity.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-accrual-periodicity.rst
@@ -4,4 +4,4 @@
 :Requirement Level: optional
 :Cardinality: 0..1
 :Description: The frequency in which this dataset is updated.
-:Usage Note: Please provide URI of the controlled vocabulary
+:Usage Note: Please provide a term of the controlled vocabulary in the form of an URI.

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-coverage.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-coverage.rst
@@ -5,6 +5,6 @@
 :Requirement Level: optional
 :Cardinality: 0..n
 :Description: The location or time a dataset covers.
-:Usage Notes: This property is deappreciated.
-             Consider to use ``dct:temporal`` or ``dct:spatial``.
-             If a date is provided, it does not have to be an ISO date.
+:Usage Notes: This property is deprecated.
+              Consider to use ``dct:temporal`` or ``dct:spatial``.
+              If a date is provided, it does not have to be an ISO date.

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-description.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-description.rst
@@ -3,6 +3,6 @@
 :Value: ``rdfs:Literal`` http://www.w3.org/TR/rdf-schema/#ch_literal
 :Requirement Level: mandatory
 :Cardinality: 1..4 (one for each language)
-:Description: Title of the dataset in different languages
-:Usage Notes: Provide at least one of the languages ``en``, ``de``, ``fr``, ``it``
-             Markdown can be used in the descriptions
+:Description: Description of the dataset in different languages
+:Usage Notes: Provide at least one of the languages ``en``, ``de``, ``fr``, ``it``.
+              Markdown can be used.

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-distribution.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-distribution.rst
@@ -1,4 +1,4 @@
-:DCAT URI: dcat:distributio
+:DCAT URI: dcat:distribution
 :Domain: dcat:Dataset
 :Value: dcat:Distribution
 :Requirement Level: mandatory

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-identifier.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-identifier.rst
@@ -1,15 +1,16 @@
- :DCAT URI: dct:identifier
- :Value: ``rdfs:Literal`` http://www.w3.org/TR/rdf-schema/#ch_literal with
-         special requirements, see Usage Notes
- :Requirement Level: mandatory
- :Cardinality: 1..1
- :Description: Unique identifier of the dataset across all publishers.
- :Usage Notes: The identifier is expected in the following structure:
-               ``[Source-Dataset-ID]@[Source-Organisation-ID]`` where
-               ``[Source-Organisation-ID]`` is the :term:`slug <Slug>` of
-               the organization on opendata.swiss.
-               ``[Source-Dataset-ID]`` needs to be unique within the
-               datasets of the organization. A recommended way to choose this
-               is to use the ID in the source system of the
-               publisher. It can consist out of the following characters
-               ``A-Za-z``, ``0-9`` and ``-`` and ``_``
+:DCAT URI: dct:identifier
+:Domain: dcat:Catalog
+:Value: ``rdfs:Literal`` http://www.w3.org/TR/rdf-schema/#ch_literal with
+        special requirements, see Usage Notes
+:Requirement Level: mandatory
+:Cardinality: 1..1
+:Description: Unique identifier of the dataset across all publishers.
+:Usage Notes: The identifier is expected in the following structure:
+              ``[Source-Dataset-ID]@[Source-Organisation-ID]`` where
+              ``[Source-Organisation-ID]`` is the :term:`slug <Slug>` of
+              the organization on opendata.swiss.
+              ``[Source-Dataset-ID]`` needs to be unique within the
+              datasets of the organization. A recommended way to choose this
+              is to use the ID in the source system of the
+              publisher. It can consist out of the following characters
+              ``A-Za-z``, ``0-9`` and ``-`` and ``_``

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-identifier.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-identifier.rst
@@ -1,6 +1,6 @@
  :DCAT URI: dct:identifier
  :Value: ``rdfs:Literal`` http://www.w3.org/TR/rdf-schema/#ch_literal with
-         special requirements, see Usage Note
+         special requirements, see Usage Notes
  :Requirement Level: mandatory
  :Cardinality: 1..1
  :Description: Unique identifier of the dataset across all publishers.
@@ -9,7 +9,7 @@
                ``[Source-Organisation-ID]`` is the :term:`slug <Slug>` of
                the organization on opendata.swiss.
                ``[Source-Dataset-ID]`` needs to be unique within the
-               datasets of the organization. A reccommended way to choose this
-               is to use the ID in the source system of the publisher
-               The can consists out of the following characters
+               datasets of the organization. A recommended way to choose this
+               is to use the ID in the source system of the
+               publisher. It can consist out of the following characters
                ``A-Za-z``, ``0-9`` and ``-`` and ``_``

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-issued.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-issued.rst
@@ -2,5 +2,5 @@
 :Value: Date and time in `ISO-8601 <https://en.wikipedia.org/wiki/ISO_8601>`__ format
 :Requirement Level: conditional: required once the the dataset is published
 :Cardinality: 0..1
-:Description: Date of the first issuance of the dataset
-:Usage Note: May be missing if the dataset is in preparation
+:Description: Date of the first publication of the dataset
+:Usage Note: Can be empty while the dataset is in preparation.

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-issued.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-issued.rst
@@ -1,4 +1,5 @@
 :DCAT URI: dct:issued
+:Domain: dcat:Dataset
 :Value: Date and time in `ISO-8601 <https://en.wikipedia.org/wiki/ISO_8601>`__ format
 :Requirement Level: conditional: required once the the dataset is published
 :Cardinality: 0..1

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-keyword.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-keyword.rst
@@ -1,6 +1,6 @@
 :DCAT URI: dct:keyword
 :Value: ``rdfs:Literal`` http://www.w3.org/TR/rdf-schema/#ch_literal
-:Requirement Level: optionsl
+:Requirement Level: optional
 :Cardinality: 0..n
 :Description: Keywords that match the topic of the dataset and help datausers to find it
-:Usage Note: Keyword are added as localized strings in the 4 languages ``en``, ``de``, ``fr``, ``it``
+:Usage Note: Keywords have to be added as localized strings in the 4 languages ``en``, ``de``, ``fr``, ``it``

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-keyword.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-keyword.rst
@@ -1,5 +1,5 @@
 :DCAT URI: dct:keyword
-:Domain: dcat:Catalog
+:Domain: dcat:Dataset
 :Value: ``rdfs:Literal`` http://www.w3.org/TR/rdf-schema/#ch_literal
 :Requirement Level: optional
 :Cardinality: 0..n

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-keyword.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-keyword.rst
@@ -1,6 +1,7 @@
 :DCAT URI: dct:keyword
+:Domain: dcat:Catalog
 :Value: ``rdfs:Literal`` http://www.w3.org/TR/rdf-schema/#ch_literal
 :Requirement Level: optional
 :Cardinality: 0..n
 :Description: Keywords that match the topic of the dataset and help datausers to find it
-:Usage Note: Keywords have to be added as localized strings in the 4 languages ``en``, ``de``, ``fr``, ``it``
+:Usage Notes: Keywords have to be added as localized strings in the 4 languages ``en``, ``de``, ``fr``, ``it``

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-landing-page.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-landing-page.rst
@@ -4,6 +4,6 @@
 :Requirement Level: optional
 :Cardinality: 0..1
 :Description: Website of the dataset with related information
-:Usage Notes: If data of the dataset is only accessible only via a landing page
+:Usage Notes: If data of the dataset is only accessible via a landing page
               (i.e. direct download URLs are not known), the landing page must be set and
-              the link should be duplicated as accessURL on a distributions.
+              the link should be duplicated as ``dcat:accessURL`` on a distributions.

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-landing-page.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-landing-page.rst
@@ -6,4 +6,4 @@
 :Description: Website of the dataset with related information
 :Usage Notes: If data of the dataset is only accessible via a landing page
               (i.e. direct download URLs are not known), the landing page must be set and
-              the link should be duplicated as ``dcat:accessURL`` on a distributions.
+              the link should be duplicated as ``dcat:accessURL`` on a distribution.

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-landing-page.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-landing-page.rst
@@ -4,11 +4,6 @@
 :Requirement Level: optional
 :Cardinality: 0..1
 :Description: Website of the dataset with related information
-:Usage Note: The current implementation does not conform DCAT-AP-CH
-            Webpage that can be navigated to in a Web browser to gain access to the dataset,
-            its distributions and/or additional information.
-            If distributions are accessible only through a landing page
-            (i.e. direct download URLs are not known), the landing page link should be duplicated as
-            accessURL on the distributions.
-:DCAT-AP-CH: The current implementation on opendata.swiss of the landing page as a string
-            does not conform DCAT-AP-CH.
+:Usage Note: If data of the dataset is only accessible only via a landing page
+             (i.e. direct download URLs are not known), the landing page must be set and
+             the link should be duplicated as accessURL on a distributions.

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-landing-page.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-landing-page.rst
@@ -4,6 +4,6 @@
 :Requirement Level: optional
 :Cardinality: 0..1
 :Description: Website of the dataset with related information
-:Usage Note: If data of the dataset is only accessible only via a landing page
-             (i.e. direct download URLs are not known), the landing page must be set and
-             the link should be duplicated as accessURL on a distributions.
+:Usage Notes: If data of the dataset is only accessible only via a landing page
+              (i.e. direct download URLs are not known), the landing page must be set and
+              the link should be duplicated as accessURL on a distributions.

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-language.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-language.rst
@@ -4,6 +4,6 @@
 :Requirement Level: conditional
 :Cardinality: 0..n
 :Description: Languages in which distributions are available
-:Usage: Should contain all languages for which a distribution of the dataset is available.
-        If all distributions are language-independant, this field can be left out.
-        Only the languages "de", "fr", "en", "it" are currently imported to opendata.swiss
+:Usage Notes: Should contain all languages for which a distribution of the dataset is available.
+              If all distributions are language-independant, this field can be left out.
+              Only the languages "de", "fr", "en", "it" are currently imported to opendata.swiss

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-language.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-language.rst
@@ -4,6 +4,6 @@
 :Requirement Level: conditional
 :Cardinality: 0..n
 :Description: Languages in which distributions are available
-:Usage: Should contain all languages for which a distribution is available.
-       If all distributions are language-independant, this field can be left out.
-       Only the languages "de", "fr", "en", "it" are currently imported to opendata.swiss
+:Usage: Should contain all languages for which a distribution of the dataset is available.
+        If all distributions are language-independant, this field can be left out.
+        Only the languages "de", "fr", "en", "it" are currently imported to opendata.swiss

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-modified.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-modified.rst
@@ -1,7 +1,7 @@
 :DCAT URI: dct:modified
 :Domain: dcat:Dataset
 :Value: Date and time in `ISO-8601 <https://en.wikipedia.org/wiki/ISO_8601>`__ format
-:Requirement Level: conditional: required when the dataset has changed since the
-                   first publication
+:Requirement Level: conditional: required when the dataset has changed since its
+                    first publication
 :Cardinality: 0..1
-:Description: Date of the last change (since the first publication on opendata.swiss)
+:Description: Date of the last change

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-publisher.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-publisher.rst
@@ -4,8 +4,7 @@
 :Requirement Level: mandatory
 :Cardinality: 1..1
 :Description: The publisher is the organization with the legal authority
-             to publish the dataset.
-:Usage Notes: The publisher as it is implemented on opendata.swiss is currently
-              not conformant to DCAT-AP-CH and DCAT-AP.
-:DCAT-AP-CH:  Implementation on opendata swiss does not conform to DCAT-AP-CH, since
-              it is not a class of foaf:Agent, that is mapped.
+              to publish the dataset.
+:Usage Notes: See here for the difference between ``dct:publisher`` and
+              ``dcat:contactPoint``:
+              https://joinup.ec.europa.eu/release/how-are-publisher-and-contact-point-modelled

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-publisher.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-publisher.rst
@@ -5,7 +5,7 @@
 :Cardinality: 1..1
 :Description: The publisher is the organization with the legal authority
              to publish the dataset.
-:Usage Notes: The publsher is currently not conformant to DCAT-AP-CH and DCAT-AP
-             as it is implemented on opendata.swiss
-:DCAT-AP-CH:  Implementation on opendata swiss does not conform DCAT-AP-CH, since
-             it is not a class of foaf:Agent, that is mapped.
+:Usage Notes: The publisher as it is implemented on opendata.swiss is currently
+              not conformant to DCAT-AP-CH and DCAT-AP.
+:DCAT-AP-CH:  Implementation on opendata swiss does not conform to DCAT-AP-CH, since
+              it is not a class of foaf:Agent, that is mapped.

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-relation.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-relation.rst
@@ -4,6 +4,6 @@
 :Requirement Level: optional
 :Cardinality: 0..n
 :Description: related resource
-:Usage Note: link to documents that provide further information for the dataset
-            This property is also used to link to the legal basis regarding
-            the publication of the dataset
+:Usage Note: Link to documents that provide further information for the dataset.
+             This property is also used to link to the legal basis regarding
+             the publication of the dataset

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-see-alsos.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-see-alsos.rst
@@ -5,4 +5,3 @@
 :Cardinality: 0..n
 :Description: Link to related datasets. Contains the identifier of the linked dataset.
 :Usage Note: Contains the identifier of the linked dataset.
-:DCAT-AP-CH: this should contain a URI instead: this is not conformant with DCAT-AP-CH

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-see-alsos.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-see-alsos.rst
@@ -4,4 +4,4 @@
 :Requirement Level: optional
 :Cardinality: 0..n
 :Description: Link to related datasets. Contains the identifier of the linked dataset.
-:Usage Note: Contains the identifier of the linked dataset.
+:Usage Notes: Contains the identifier of the linked dataset.

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-spatial.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-spatial.rst
@@ -4,7 +4,7 @@
 :Requirement Level: optional
 :Cardinality: 0..n
 :Description: Geographical classification of the dataset.
-:Usage Note: Can be a description, coordinates, a bounding-box or a polygon.
-            This field currently supports GeoJSON with the
-            `LOCN extension <https://www.w3.org/community/locadd/wiki/LOCN_extension:_Metadata>`__ .
-            See also: `How should dct:spatial and dct:Location be used? <https://joinup.ec.europa.eu/release/how-should-dctspatial-and-dctlocation-be-used>`__                                |
+:Usage Notes: Can be a description, coordinates, a bounding-box or a polygon.
+              This field currently supports GeoJSON with the
+              `LOCN extension <https://www.w3.org/community/locadd/wiki/LOCN_extension:_Metadata>`__ .
+              See also: `How should dct:spatial and dct:Location be used? <https://joinup.ec.europa.eu/release/how-should-dctspatial-and-dctlocation-be-used>`__                                |

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-temporal.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-temporal.rst
@@ -5,5 +5,5 @@
 :Cardinality: 0..n
 :Description: One or more time period(s) that the dataset covers.
 :Usage Note: ``<schema:startDate>`` contains the start date,
-            ``<schema:endDate>`` contains the end date, format for dates:
+            ``<schema:endDate>`` contains the end date. Valid date formats can be found here:
             http://www.w3.org/2001/XMLSchema#date

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-temporal.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-temporal.rst
@@ -4,6 +4,6 @@
 :Requirement Level: optional
 :Cardinality: 0..n
 :Description: One or more time period(s) that the dataset covers.
-:Usage Note: ``<schema:startDate>`` contains the start date,
-            ``<schema:endDate>`` contains the end date. Valid date formats can be found here:
-            http://www.w3.org/2001/XMLSchema#date
+:Usage Notes: ``<schema:startDate>`` contains the start date,
+              ``<schema:endDate>`` contains the end date. Valid date formats can be found here:
+              http://www.w3.org/2001/XMLSchema#date

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-theme.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-theme.rst
@@ -1,6 +1,5 @@
 :DCAT URI: dcat:theme
 :Domain: dcat:Dataset
-:Value: dcat:Dataset
 :Value: DCAT-AP-CH has its own controlled vocabulary for the theme:
        `in rdf <https://ogdch-new-handbook.clients.liip.ch/theme.rdf>`__
        `in turtle <https://ogdch-new-handbook.clients.liip.ch/theme.ttl>`__

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-theme.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-theme.rst
@@ -1,7 +1,7 @@
 :DCAT URI: dcat:theme
 :Domain: dcat:Dataset
 :Value: DCAT-AP-CH has its own
-        `controlled vocabulary for the theme <https://dcat-ap.ch/vocabulary/themes>`__
+        `controlled vocabulary for the themes <https://dcat-ap.ch/vocabulary/themes>`__
 :Requirement Level: optional
 :Cardinality: 0..n
 :Description: Categories that match the topic of the dataset

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-theme.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-theme.rst
@@ -1,7 +1,7 @@
 :DCAT URI: dcat:theme
 :Domain: dcat:Dataset
 :Value: dcat:Dataset
-:Value: DCAT-AP-CH has its own controlled vocabulary fot the theme:
+:Value: DCAT-AP-CH has its own controlled vocabulary for the theme:
        `in rdf <https://ogdch-new-handbook.clients.liip.ch/theme.rdf>`__
        `in turtle <https://ogdch-new-handbook.clients.liip.ch/theme.ttl>`__
 :Requirement Level: optional

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-theme.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-theme.rst
@@ -1,8 +1,7 @@
 :DCAT URI: dcat:theme
 :Domain: dcat:Dataset
-:Value: DCAT-AP-CH has its own controlled vocabulary for the theme:
-       `in rdf <https://ogdch-new-handbook.clients.liip.ch/theme.rdf>`__
-       `in turtle <https://ogdch-new-handbook.clients.liip.ch/theme.ttl>`__
+:Value: DCAT-AP-CH has its own
+        `controlled vocabulary for the theme <https://dcat-ap.ch/vocabulary/themes>`__
 :Requirement Level: optional
 :Cardinality: 0..n
 :Description: Categories that match the topic of the dataset

--- a/source/content/glossar/bibliothek/dcat-definitions/dataset-title.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/dataset-title.rst
@@ -4,4 +4,4 @@
 :Requirement Level: mandatory
 :Cardinality: 1..4 (one for each language)
 :Description: Title of the dataset in different languages
-:Usage Notes: Provide at least on of the languages ``en``, ``de``, ``fr``, ``it``
+:Usage Notes: Provide at least one of the languages ``en``, ``de``, ``fr``, ``it``

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-access-url.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-access-url.rst
@@ -4,6 +4,6 @@
 :Requirement Level: mandatory
 :Cardinality: 1..n
 :Description: URL where the distribution can be found. This could be either a download URL, an API URL or
-             a landing page URL. If the distribution is only available through a landing page,
-             this field must contain the URL of the landing page. If a download URL was given for this distribution,
-             this field has to contain the same value.
+              a landing page URL. If the distribution is only available through a landing page,
+              this field must contain the URL of the landing page. If a download URL was given for this distribution,
+              this field has to contain the same value.

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-class.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-class.rst
@@ -1,5 +1,5 @@
 :DCAT URI: dcat:Distribution
 :Requirement Level: mandatory
 :Cardinality: 1..n
-:Description: A single distributiom of a dataset
+:Description: A single distribution of a dataset
 :Usage Notes: Provide at least one distribution per dataset

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-coverage.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-coverage.rst
@@ -6,4 +6,5 @@
 :Cardinality: 0..n
 :Description: Distributions can be marked by a location or time period (for example, one for each canton,
               one for each year, etc.)
-:Usage Notes: If a date is provided, it does not have to be an ISO date.
+:Usage Notes: This property is a string: so when it is used to indicate a date a custom format
+              can be used.

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-description.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-description.rst
@@ -2,7 +2,7 @@
 :Domain: dcat:Distribution
 :Value: ``rdfs:Literal`` http://www.w3.org/TR/rdf-schema/#ch_literal
 :Requirement Level: conditional: required if the distribution does not contain all the content of the dataset.
-:Cardinality: 1..4 (one for each language)
+:Cardinality: 0..4 (one for each language)
 :Description: Title of the dataset in different languages
 :Usage Notes: Provide at least one of the languages ``en``, ``de``, ``fr``, ``it``
               Markdown can be used in the descriptions

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-download-url.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-download-url.rst
@@ -4,5 +4,5 @@
 :Requirement Level: optional
 :Cardinality: 0..n
 :Description: URL for the download, if the distribution can be downloaded
-:Usage Note: In this case the property usually has the same url as ``dcat:accessURL``,
-             see also https://www.w3.org/ns/dcat#downloadURL
+:Usage Notes: In this case the property usually has the same url as ``dcat:accessURL``,
+              see also https://www.w3.org/ns/dcat#downloadURL

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-download-url.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-download-url.rst
@@ -3,7 +3,6 @@
 :Value: URI: http://www.w3.org/2001/XMLSchema#anyURI
 :Requirement Level: optional
 :Cardinality: 0..n
-:Description: Website of the dataset with related information
-:Usage Note: URL for the download, if the distribution can be downloaded: in this
-            case the property usually has the same url as ``dcat:accessURL``,
-            see also https://www.w3.org/ns/dcat#downloadURL
+:Description: URL for the download, if the distribution can be downloaded
+:Usage Note: In this case the property usually has the same url as ``dcat:accessURL``,
+             see also https://www.w3.org/ns/dcat#downloadURL

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-format.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-format.rst
@@ -5,4 +5,4 @@
 :Cardinality: 0..1
 :Description: Format of the distribution
 :Usage Notes: If neither the ``downloadURL`` nor the ``mediaType`` provide a
-              valid format, this value is used to display the format of the ressource.
+              valid format, this value is used to display the format of the distribution.

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-language.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-language.rst
@@ -4,6 +4,6 @@
 :Requirement Level: optional
 :Cardinality: 0..n
 :Description: Languages in which this distribution is available.
-:Usage: If the distribution is language-independant, this can
+:Usage: If the distribution is language independent, this can
        be left out.
        Only the languages "de", "fr", "en", "it" are currently imported to opendata.swiss

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-language.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-language.rst
@@ -4,6 +4,6 @@
 :Requirement Level: optional
 :Cardinality: 0..n
 :Description: Languages in which this distribution is available.
-:Usage: If the distribution is language independent, this can
-       be left out.
-       Only the languages "de", "fr", "en", "it" are currently imported to opendata.swiss
+:Usage Notes: If the distribution is language independent, this can
+              be left out.
+              Only the languages "de", "fr", "en", "it" are currently imported to opendata.swiss

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-license.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-license.rst
@@ -4,4 +4,4 @@
 :Requirement Level: optinal
 :Cardinality: 0..1
 :Description: Rights statement of this distribution. It relates to the ``dcat:accessURL``
-:Usage Note: Not used, see ``dct:rights``. This field ensures compatibility to other metadata standards.
+:Usage Notes: Not used, see ``dct:rights``. This field ensures compatibility to other metadata standards.

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-media-type.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-media-type.rst
@@ -3,5 +3,5 @@
 :Value: `dct:MediaTypeOrExtent`` must be a MIME type of http://www.iana.org/assignments/media-types/media-types.xhtml
 :Requirement Level: conditional, required if the distribution is  a file accessible by a ``dcat:downloadURL``
 :Cardinality: 0..1
-:Description: Resource format of the data provided by the download url
+:Description: Resource format of the data provided by the ``dcat:downloadURL``
 :Usage Notes: Not required for distributions that have only a ``dcat:accessURL``

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-rights.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-rights.rst
@@ -6,7 +6,7 @@
 :Description: Rights statement that is relevant for the dcat:accessURL of this distribution.
 :Usage Notes: The rights statement declares for which purpose and in which context
               the data of a distribution can be used: for commercial purposes or only for
-              non commercial purposes. Does it need be referenced, when it is used? These
+              non commercial purposes. Does it need to be referenced, when it is used? These
               conditions are all captured in the right statements. For the exact values,
               see the list below.
 

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-rights.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-rights.rst
@@ -3,9 +3,8 @@
 :Value: ``rdfs:Literal`` http://www.w3.org/TR/rdf-schema/#ch_literal
 :Requirement Level: mandatory
 :Cardinality: 1..1
-:Description: Rights statement of this distribution. It relates to the ``dcat:accessURL``
+:Description: Rights statement that is relevant for the dcat:accessURL of this distribution.
 :Usage Note: The rights statement is composed of 3 elements that can be merged and summarized as a literal:
-:Mapping: 'Non-commercial use', 'Commercial use' and 'Reference' are combined with 'Allowed', 'WithPermission', 'Required', etc.
 
 .. code-block::
     :caption: Values acceptable for opendata.swiss

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-rights.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-rights.rst
@@ -4,7 +4,7 @@
 :Requirement Level: mandatory
 :Cardinality: 1..1
 :Description: Rights statement that is relevant for the dcat:accessURL of this distribution.
-:Usage Note: The rights statement is composed of 3 elements that can be merged and summarized as a literal:
+:Usage Notes: The rights statement is composed of 3 elements that can be merged and summarized as a literal:
 
 .. code-block::
     :caption: Values acceptable for opendata.swiss

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-rights.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-rights.rst
@@ -4,7 +4,11 @@
 :Requirement Level: mandatory
 :Cardinality: 1..1
 :Description: Rights statement that is relevant for the dcat:accessURL of this distribution.
-:Usage Notes: The rights statement is composed of 3 elements that can be merged and summarized as a literal:
+:Usage Notes: The rights statement declares for which purpose and in which context
+              the data of a distribution can be used: for commercial purposes or only for
+              non commercial purposes. Does it need be referenced, when it is used? These
+              conditions are all captured in the right statements. For the exact values,
+              see the list below.
 
 .. code-block::
     :caption: Values acceptable for opendata.swiss

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-title.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-title.rst
@@ -2,9 +2,9 @@
 :Domain: dcat:Distribution
 :Value: ``rdfs:Literal`` http://www.w3.org/TR/rdf-schema/#ch_literal
 :Requirement Level: mandatory
-:Cardinality: 1..4 (one for each language)
+:Cardinality: 0..4 (one for each language)
 :Description: The title of the distribution
 :Usage Notes: The title is mandatory if the distribution contains only a part
               of the content covered by the dataset: for example if it contains
-              only the data for one year, where as the dataset covers severel years
+              only the data for one year, whereas the dataset covers severel years
               in total.

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-title.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-title.rst
@@ -1,8 +1,10 @@
 :DCAT URI: dct:title
 :Domain: dcat:Distribution
 :Value: ``rdfs:Literal`` http://www.w3.org/TR/rdf-schema/#ch_literal
-:Mandatory: no - except if the distribution does not contain
-            all the content of the dataset.
+:Mandatory: The title is mandatory if the distribution contains only a part
+            of the content covered by the dataset: for example if it contains
+            only the data for one year, where as the dataset covers severel years
+            in total.
 :Cardinality: 0..n (one for each language)
 :Attributes: - Name: ``xml:lang``
              - Content: ``en``, ``de``, ``fr``, ``it``

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-title.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-title.rst
@@ -6,5 +6,5 @@
 :Description: The title of the distribution
 :Usage Notes: The title is mandatory if the distribution contains only a part
               of the content covered by the dataset: for example if it contains
-              only the data for one year, whereas the dataset covers severel years
+              only the data for one year, whereas the dataset covers several years
               in total.

--- a/source/content/glossar/bibliothek/dcat-definitions/distribution-title.rst
+++ b/source/content/glossar/bibliothek/dcat-definitions/distribution-title.rst
@@ -1,15 +1,10 @@
 :DCAT URI: dct:title
 :Domain: dcat:Distribution
 :Value: ``rdfs:Literal`` http://www.w3.org/TR/rdf-schema/#ch_literal
-:Mandatory: The title is mandatory if the distribution contains only a part
-            of the content covered by the dataset: for example if it contains
-            only the data for one year, where as the dataset covers severel years
-            in total.
-:Cardinality: 0..n (one for each language)
-:Attributes: - Name: ``xml:lang``
-             - Content: ``en``, ``de``, ``fr``, ``it``
-             - Description: Language of the element
-             - Mandatory: yes
-:Description: The title of the distribution in the language defined
-              by the ``xml:lang?`` attribute. If this element is left out,
-              the ``dct:title`` of the dataset is used instead.
+:Requirement Level: mandatory
+:Cardinality: 1..4 (one for each language)
+:Description: The title of the distribution
+:Usage Notes: The title is mandatory if the distribution contains only a part
+              of the content covered by the dataset: for example if it contains
+              only the data for one year, where as the dataset covers severel years
+              in total.

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-accrual-periodicity-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-accrual-periodicity-rdf.rst
@@ -1,5 +1,5 @@
 .. code-block:: xml
-    :caption: daily updated dataset
+    :caption: dataset that is updated on a daily basis
     :emphasize-lines: 7
 
     <?xml version="1.0" encoding="utf-8" ?>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-accrual-periodicity-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-accrual-periodicity-ttl.rst
@@ -1,5 +1,5 @@
 .. code-block:: Turtle
-    :caption: daily updated dataset
+    :caption: dataset that is updated on a daily basis
     :emphasize-lines: 6
 
     @prefix dcat: <http://www.w3.org/ns/dcat#> .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-landing-page-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-landing-page-rdf.rst
@@ -1,5 +1,5 @@
 .. code-block:: xml
-    :caption: The landing page in the current implementation is a string
+    :caption: The landing page is provided as a string
     :emphasize-lines: 6
 
     <?xml version="1.0" encoding="utf-8" ?>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-landing-page-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-landing-page-rdf.rst
@@ -1,5 +1,5 @@
 .. code-block:: xml
-    :caption: The landing Page in the current implementation is a string
+    :caption: The landing page in the current implementation is a string
     :emphasize-lines: 6
 
     <?xml version="1.0" encoding="utf-8" ?>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-landing-page-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-landing-page-ttl.rst
@@ -1,5 +1,5 @@
 .. code-block:: Turtle
-    :caption: The landing Page in the current implementation is a string
+    :caption: The landing page in the current implementation is a string
     :emphasize-lines: 5
 
     @prefix dcat: <http://www.w3.org/ns/dcat#> .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-landing-page-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-landing-page-ttl.rst
@@ -1,5 +1,5 @@
 .. code-block:: Turtle
-    :caption: The landing page in the current implementation is a string
+    :caption: The landing page is provided as a string
     :emphasize-lines: 5
 
     @prefix dcat: <http://www.w3.org/ns/dcat#> .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-spatial-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-spatial-ttl.rst
@@ -3,8 +3,8 @@
     :emphasize-lines: 6
 
     @prefix dcat: <http://www.w3.org/ns/dcat#> .
-    @prefix dc: <http://purl.org/dc/terms/> .
+    @prefix dct: <http://purl.org/dc/terms/> .
 
     <https://swisstopo/123>
       a dcat:Dataset ;
-      dc:spatial <http://publications.europa.eu/mdr/authority/country/ZWE>, "Bern" .
+      dct:spatial <http://publications.europa.eu/mdr/authority/country/ZWE>, "Bern" .


### PR DESCRIPTION
- the suggestions from the dev review are implemented, except for the more complicated dct:spatial example: I will add that later in an extra PR if I have time for it
- the key words used in the dcat-defintions have been harmonized
- in the table the conformance column is dropped and all conformance remarks have been removed