### PR TITLE
add exemples for geocat mappings

### DIFF
--- a/source/content/glossar/bibliothek/geocat-examples/dataset-accrual-periodicity.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-accrual-periodicity.rst
@@ -1,0 +1,9 @@
+.. code-block:: xml
+    :caption: Picking up the update frequency: here "annually"
+    :emphasize-lines: 4
+
+    <gmd:maintenanceAndUpdateFrequency>
+        <gmd:MD_MaintenanceFrequencyCode
+            codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode"
+            codeListValue="annually"/>
+    </gmd:maintenanceAndUpdateFrequency>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-contact-point.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-contact-point.rst
@@ -1,0 +1,123 @@
+.. code-block:: xml
+    :caption: ``//gmd:contact`` the role "pointOfContact" is taken for ``dcat:contactPoint``
+    :emphasize-lines: 48,49,50,88,89,90,91
+
+    <gmd:contact xlink:show="embed">
+        <che:CHE_CI_ResponsibleParty xmlns:geonet="http://www.fao.org/geonetwork" gco:isoType="gmd:CI_ResponsibleParty">
+            <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Bundesamt für Raumentwicklung</gco:CharacterString>
+                <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">Bundesamt für Raumentwicklung
+                        </gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#FR">Office fédéral du développement territorial
+                        </gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#IT">Ufficio federale dello sviluppo territoriale
+                        </gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#EN">Federal Office for Spatial Development
+                        </gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#RM">Bundesamt für Raumentwicklung
+                        </gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                </gmd:PT_FreeText>
+            </gmd:organisationName>
+            <gmd:contactInfo>
+                <gmd:CI_Contact>
+                    <gmd:phone>
+                        <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+                            <che:directNumber>
+                                <gco:CharacterString>+41 58 462 01 43</gco:CharacterString>
+                            </che:directNumber>
+                        </che:CHE_CI_Telephone>
+                    </gmd:phone>
+                    <gmd:address>
+                        <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+                            <gmd:city>
+                                <gco:CharacterString>Ittigen</gco:CharacterString>
+                            </gmd:city>
+                            <gmd:postalCode>
+                                <gco:CharacterString>3063</gco:CharacterString>
+                            </gmd:postalCode>
+                            <gmd:country>
+                                <gco:CharacterString>CH</gco:CharacterString>
+                            </gmd:country>
+                            <gmd:electronicMailAddress>
+                                <gco:CharacterString>rolf.giezendanner@are.admin.ch</gco:CharacterString>
+                            </gmd:electronicMailAddress>
+                            <che:streetName>
+                                <gco:CharacterString>Worblentalstrasse</gco:CharacterString>
+                            </che:streetName>
+                            <che:streetNumber>
+                                <gco:CharacterString>66</gco:CharacterString>
+                            </che:streetNumber>
+                        </che:CHE_CI_Address>
+                    </gmd:address>
+                    <gmd:onlineResource>
+                        <gmd:CI_OnlineResource>
+                            <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                                <gmd:URL>http://www.are.admin.ch</gmd:URL>
+                                <che:PT_FreeURL>
+                                    <che:URLGroup>
+                                        <che:LocalisedURL locale="#DE">http://www.are.admin.ch</che:LocalisedURL>
+                                    </che:URLGroup>
+                                    <che:URLGroup>
+                                        <che:LocalisedURL locale="#FR">http://www.are.admin.ch</che:LocalisedURL>
+                                    </che:URLGroup>
+                                    <che:URLGroup>
+                                        <che:LocalisedURL locale="#IT">http://www.are.admin.ch</che:LocalisedURL>
+                                    </che:URLGroup>
+                                    <che:URLGroup>
+                                        <che:LocalisedURL locale="#EN">http://www.are.admin.ch</che:LocalisedURL>
+                                    </che:URLGroup>
+                                    <che:URLGroup>
+                                        <che:LocalisedURL locale="#RM">http://www.are.admin.ch</che:LocalisedURL>
+                                    </che:URLGroup>
+                                </che:PT_FreeURL>
+                            </gmd:linkage>
+                            <gmd:protocol>
+                                <gco:CharacterString>text/html</gco:CharacterString>
+                            </gmd:protocol>
+                        </gmd:CI_OnlineResource>
+                    </gmd:onlineResource>
+                </gmd:CI_Contact>
+            </gmd:contactInfo>
+            <gmd:role>
+                <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode"
+                                 codeListValue="pointOfContact"/>
+            </gmd:role>
+            <che:individualFirstName>
+                <gco:CharacterString>Rolf</gco:CharacterString>
+            </che:individualFirstName>
+            <che:individualLastName>
+                <gco:CharacterString>Giezendanner</gco:CharacterString>
+            </che:individualLastName>
+            <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>ARE</gco:CharacterString>
+                <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">ARE</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#FR">ARE</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#IT">ARE</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#EN">ARE</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#RM">ARE</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                </gmd:PT_FreeText>
+            </che:organisationAcronym>
+        </che:CHE_CI_ResponsibleParty>
+    </gmd:contact>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-description.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-description.rst
@@ -1,0 +1,61 @@
+.. code-block:: xml
+    :caption: Example of getting ``dct:description``: only 4 languages are taken: DE, EN, FR, IT
+    :emphasize-lines: 11,12,13,14,15,16,17,21,22,23,24,25,26,27,30,31,31,32,33,34,35,36,40,41,42,43,44,45
+
+    <gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Dans le cas de travaux de terrain réalisés pour la mensuration officielle, un ajustage local
+            doit systématiquement être exécuté sauf si la preuve peut être apporté qu’il peut y être renoncé. Un tel
+            ajustage local est superflu dans les zones où les tensions sont négligeables parce que la précision géométrique
+            satisfait à des critères de qualité très élevés. Dans la pratique quotidienne, la connaissance des zones où les
+            tensions sont négligeables facilite l’emploi des méthodes de mesure basées sur des satellites, en particulier le
+            recours à des services de positionnement.
+        </gco:CharacterString>
+        <gmd:PT_FreeText>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Dans le cas de travaux de terrain réalisés pour la mensuration
+                    officielle, un ajustage local doit systématiquement être exécuté sauf si la preuve peut être apporté
+                    qu’il peut y être renoncé. Un tel ajustage local est superflu dans les zones où les tensions sont
+                    négligeables parce que la précision géométrique satisfait à des critères de qualité très élevés. Dans la
+                    pratique quotidienne, la connaissance des zones où les tensions sont négligeables facilite l’emploi des
+                    méthodes de mesure basées sur des satellites, en particulier le recours à des services de
+                    positionnement.
+                </gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Bei Feldarbeiten in der amtlichen Vermessung muss jeweils eine
+                    lokale Einpassung durchgeführt werden oder zumindest der Nachweis erbracht werden, dass auf eine solche
+                    verzichtet werden kann. In spannungsarmen Gebieten erübrigt sich eine lokale Einpassung, weil die
+                    geometrische Genauigkeit erhöhten Qualitätskriterien entspricht. In der praktischen Anwendung
+                    erleichtert die Kenntnis solcher spannungsarmen Gebiete die Arbeiten mit satellitengestützten
+                    Messmethoden, insbesondere mit Positionierungsdiensten wie zum Beispiel swipos.
+                </gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Nel caso di lavori sul campo eseguiti per la misurazione
+                    ufficiale occorre effettuare di volta in volta un aggiustamento locale o quanto meno fornire la prova
+                    che è possibile rinunciare a tale aggiustamento. Nelle zone di tensioni trascurabili un aggiustamento
+                    locale diviene superfluo, perché l'esattezza geometrica soddisfa criteri di qualità superiori.
+                    Nell'applicazione pratica, la conoscenza di queste zone di tensioni trascurabili facilita il lavoro con
+                    i metodi di misurazione satellitari e in particolare con servizi di posizionamento quali ad esempio
+                    swipos.
+                </gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">During fieldwork in the official cadastral survey, a local
+                    adaptation must be made or proof must be provided that this is not needed. In low distortion areas, a
+                    local adaptation is not necessary, because the geometric accuracy complies with higher quality criteria.
+                    In practical applications, knowledge of low distortion areas makes working with satellite:based
+                    measuring methods easier, in particular with positioning services such as swipos.
+                </gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">En cas da lavurs champestras che vegnan fatgas per la mesiraziun
+                    uffiziala sto vegnir fatga mintgamai in'adattaziun locala u almain vegnir furnida la cumprova ch'ins po
+                    renunziar ad ina tala. En territoris cun tensiuns negligiblas n'è in'adattaziun locala betg necessaria,
+                    perquai che la precisiun geometrica correspunda a criteris da qualitad fitg auts. En la pratica
+                    quotidiana facilitescha l'enconuschientscha da tals territoris cun tensiuns negligiblas l'applicaziun da
+                    metodas da mesiraziun per satellit, cunzunt tras servetschs da posiziunament sco per exempel swipos.
+                </gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+        </gmd:PT_FreeText>
+    </gmd:abstract>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-distribution.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-distribution.rst
@@ -1,0 +1,34 @@
+.. code-block:: xml
+    :caption: Getting all distribution protocols for a dataset with ``//gmd:distributionInfo/gmd:MD_Distribution//gmd:transferOptions//gmd:CI_OnlineResource//gmd:protocol``
+    :emphasize-lines: 2,5,8,11,14,20,26,29
+
+    <gmd:protocol>
+        <gco:CharacterString>ESRI:REST</gco:CharacterString>
+    </gmd:protocol>
+    <gmd:protocol>
+        <gco:CharacterString>OGC:WMS</gco:CharacterString>
+    </gmd:protocol>
+    <gmd:protocol>
+        <gco:CharacterString>WWW:DOWNLOAD:INTERLIS</gco:CharacterString>
+    </gmd:protocol>
+    <gmd:protocol>
+        <gco:CharacterString>MAP:Preview</gco:CharacterString>
+    </gmd:protocol>
+    <gmd:protocol>
+        <gco:CharacterString>WWW:DOWNLOAD:APP</gco:CharacterString>
+    </gmd:protocol>
+    <gmd:protocol>
+        <gco:CharacterString>WWW:LINK</gco:CharacterString>
+    </gmd:protocol>
+    <gmd:protocol>
+        <gco:CharacterString>WWW:DOWNLOAD:URL</gco:CharacterString>
+    </gmd:protocol>
+    <gmd:protocol>
+        <gco:CharacterString>CHTOPO:specialised:geoportal</gco:CharacterString>
+    </gmd:protocol>
+    <gmd:protocol>
+        <gco:CharacterString>OGC:WFS</gco:CharacterString>
+    </gmd:protocol>
+    <gmd:protocol>
+        <gco:CharacterString>LINKED:DATA</gco:CharacterString>
+    </gmd:protocol>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-identifier.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-identifier.rst
@@ -1,0 +1,8 @@
+.. code-block:: xml
+    :caption: getting the internal id of a dataset from ``//gmd:fileIdentifier``
+    :emphasize-lines: 2
+
+    <gmd:fileIdentifier>
+        <gco:CharacterString>93814e81-2466-4690-b54d-c1d958f1c3b8</gco:CharacterString>
+    </gmd:fileIdentifier>
+

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-issued.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-issued.rst
@@ -1,0 +1,24 @@
+ .. code-block:: xml
+    :caption: getting the "creation" date from ``//gmd:identificationInfo//gmd:citation//gmd:CI_Date``
+              to map onto ``dct:issued``
+    :emphasize-lines: 12,16,17
+
+    <gmd:CI_Date>
+        <gmd:date>
+            <gco:DateTime>2020:10:21T00:00:00</gco:DateTime>
+        </gmd:date>
+        <gmd:dateType>
+            <gmd:CI_DateTypeCode codeListValue="revision"
+                                 codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"/>
+        </gmd:dateType>
+    </gmd:CI_Date>
+    <gmd:CI_Date>
+        <gmd:date>
+            <gco:DateTime>2011:01:01T00:00:00</gco:DateTime>
+        </gmd:date>
+        <gmd:dateType>
+            <gmd:CI_DateTypeCode
+                codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                codeListValue="creation"/>
+        </gmd:dateType>
+    </gmd:CI_Date>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-keyword.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-keyword.rst
@@ -1,0 +1,116 @@
+.. code-block:: xml
+    :caption: Note that the keyword opendata.swiss is not imported
+    :emphasize-lines: 5, 8, 11, 15, 46, 49, 52, 55, 67, 68, 72, 73, 78, 79, 82, 94, 98, 102, 106
+
+    <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Bergwirtschaft</gco:CharacterString>
+        <gmd:PT_FreeText>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Bergwirtschaft</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">aménagement de la montagne</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">sfruttamento razionale della montagna
+                </gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">mountain management</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM"/>
+            </gmd:textGroup>
+        </gmd:PT_FreeText>
+    </gmd:keyword>
+    <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+    <gco:CharacterString>opendata.swiss</gco:CharacterString>
+    <gmd:PT_FreeText>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">opendata.swiss</gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">opendata.swiss</gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">opendata.swiss</gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">opendata.swiss</gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#RM">opendata.swiss</gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+    </gmd:PT_FreeText>
+    </gmd:keyword>
+    <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+    <gco:CharacterString>Alpwirtschaft</gco:CharacterString>
+    <gmd:PT_FreeText>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Alpwirtschaft</gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">économie alpestre</gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">economia alpestre</gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">alpine economy</gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#RM"/>
+        </gmd:textGroup>
+    </gmd:PT_FreeText>
+    </gmd:keyword>
+    <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+    <gco:CharacterString>Bewirtschaftungsgebiete/Schutzgebiete/geregelte Gebiete und Berichterstattungseinheiten
+    </gco:CharacterString>
+    <gmd:PT_FreeText>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Bewirtschaftungsgebiete/Schutzgebiete/geregelte Gebiete und
+                Berichterstattungseinheiten
+            </gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Zones de gestion, de restriction ou de réglementation et unités de
+                déclaration
+            </gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">Zone sottoposte a gestione/limitazioni/regolamentazione e unità con
+                obbligo di comunicare dati
+            </gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">Area management/restriction/regulation zones and reporting units
+            </gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#RM"/>
+        </gmd:textGroup>
+    </gmd:PT_FreeText>
+    </gmd:keyword>
+    <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+    <gco:CharacterString>Versorgungswirtschaft und staatliche Dienste</gco:CharacterString>
+    <gmd:PT_FreeText>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Versorgungswirtschaft und staatliche Dienste
+            </gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Services d'utilité publique et services publics
+            </gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">Servizi di pubblica utilità e servizi amministrativi
+            </gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">Utility and governmental services</gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+        <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#RM"/>
+        </gmd:textGroup>
+    </gmd:PT_FreeText>
+    </gmd:keyword>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-landing-page.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-landing-page.rst
@@ -1,0 +1,42 @@
+.. code-block:: xml
+    :caption: Mapping of the landing page from the first resource with protocol ``WWW:LINK``
+    :emphasize-lines: 3,19,20,21
+
+    <gmd:CI_OnlineResource>
+        <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+            <gmd:URL>https://swisstopo.admin.ch</gmd:URL>
+            <che:PT_FreeURL>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://swisstopo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">https://swisstopo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">https://swisstopo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">https://swisstopo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+            </che:PT_FreeURL>
+        </gmd:linkage>
+        <gmd:protocol>
+            <gco:CharacterString>WWW:LINK</gco:CharacterString>
+        </gmd:protocol>
+        <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Landing Page</gco:CharacterString>
+            <gmd:PT_FreeText>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Landing Page</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+            </gmd:PT_FreeText>
+        </gmd:name>
+        <gmd:description gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString/>
+        </gmd:description>
+        <gmd:function>
+            <gmd:CI_OnLineFunctionCode
+                codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode"
+                codeListValue="information"/>
+        </gmd:function>
+    </gmd:CI_OnlineResource>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-language.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-language.rst
@@ -1,0 +1,10 @@
+.. code-block:: xml
+    :caption: The language code is mapped from a 3 letter code to a 2 letter code
+    :emphasize-lines: 2,5
+
+    <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639:2/" codeListValue="ger"/>
+    </gmd:language>
+    <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639:2/" codeListValue="fre"/>
+    </gmd:language>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-modified.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-modified.rst
@@ -1,0 +1,24 @@
+ .. code-block:: xml
+    :caption: getting the "revision" date from ``//gmd:identificationInfo//gmd:citation//gmd:CI_Date``
+              to map onto ``dct:modified``
+    :emphasize-lines: 3,6,7
+
+    <gmd:CI_Date>
+        <gmd:date>
+            <gco:DateTime>2020:10:21T00:00:00</gco:DateTime>
+        </gmd:date>
+        <gmd:dateType>
+            <gmd:CI_DateTypeCode codeListValue="revision"
+                                 codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"/>
+        </gmd:dateType>
+    </gmd:CI_Date>
+    <gmd:CI_Date>
+        <gmd:date>
+            <gco:DateTime>2011:01:01T00:00:00</gco:DateTime>
+        </gmd:date>
+        <gmd:dateType>
+            <gmd:CI_DateTypeCode
+                codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode"
+                codeListValue="creation"/>
+        </gmd:dateType>
+    </gmd:CI_Date>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-publisher.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-publisher.rst
@@ -1,0 +1,23 @@
+.. code-block:: xml
+    :caption: The role publisher is taken in this example. Note that the localized string would not be considered
+              in this mapping
+    :emphasize-lines: 4,14,15
+
+    <gmd:pointOfContact>
+        <gmd:CI_ResponsibleParty>
+            <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Geoinformationszentrum (GIS) Stadt Luzern</gco:CharacterString>
+                <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">Geoinformationszentrum (GIS) Stadt
+                            Luzern
+                        </gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                </gmd:PT_FreeText>
+            </gmd:organisationName>
+            <gmd:role>
+                <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode"
+                                 codeListValue="publisher"/>
+            </gmd:role>
+        </gmd:CI_ResponsibleParty>
+    </gmd:pointOfContact>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-relation.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-relation.rst
@@ -1,0 +1,37 @@
+.. code-block:: xml
+    :caption: Example adding a resource of protocol "CHTOPO:specialised:geoportal" to ``dct:relation``
+    :emphasize-lines: 3,19,20,21,30-32
+
+     <gmd:CI_OnlineResource>
+        <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+            <gmd:URL>https://map.geo.admin.ch</gmd:URL>
+            <che:PT_FreeURL>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://map.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">https://map.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">https://map.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">https://map.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+            </che:PT_FreeURL>
+        </gmd:linkage>
+        <gmd:protocol>
+            <gco:CharacterString>CHTOPO:specialised:geoportal</gco:CharacterString>
+        </gmd:protocol>
+        <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Geoportal map.geo.admin.ch</gco:CharacterString>
+            <gmd:PT_FreeText>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Geoportal map.geo.admin.ch</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+            </gmd:PT_FreeText>
+        </gmd:name>
+        <gmd:description gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString/>
+        </gmd:description>
+     </gmd:CI_OnlineResource>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-see-also.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-see-also.rst
@@ -1,0 +1,11 @@
+.. code-block:: xml
+    :caption: Geocat Identifiers for ``rdfs:seeAlso``
+    :emphasize-lines: 4
+
+    <gmd:aggregateDataSetIdentifier>
+        <gmd:MD_Identifier>
+            <gmd:code>
+                <gco:CharacterString>73856ca2:f21d:4cc9:90f6:f3e8375555df</gco:CharacterString>
+            </gmd:code>
+        </gmd:MD_Identifier>
+    </gmd:aggregateDataSetIdentifier>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-spatial.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-spatial.rst
@@ -1,0 +1,24 @@
+.. code-block:: xml
+    :caption: The general character string is currently taken
+    :emphasize-lines: 2
+
+    <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Schweiz</gco:CharacterString>
+        <gmd:PT_FreeText>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Schweiz</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Schweiz</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Schweiz</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Schweiz</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+            <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#RM">Schweiz</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+        </gmd:PT_FreeText>
+    </gmd:description>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-temporal.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-temporal.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: Getting a time period for a dataset with ``//gmd:identificationInfo//gmd:extent//gmd:temporalElement``
+    :emphasize-lines: 5,6
+
+    <gmd:temporalElement>
+        <gmd:EX_TemporalExtent>
+            <gmd:extent>
+                <gml:TimePeriod gml:id="timePeriod1">
+                    <gml:beginPosition>2020-02-01T00:00:00</gml:beginPosition>
+                    <gml:endPosition>2021-04-01T23:59:59</gml:endPosition>
+                </gml:TimePeriod>
+            </gmd:extent>
+        </gmd:EX_TemporalExtent>
+    </gmd:temporalElement>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-theme.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-theme.rst
@@ -1,0 +1,10 @@
+.. code-block:: xml
+    :caption: Example of getting ``dcat:theme`` from gmd with ISO-19139_che XPath
+    :emphasize-lines: 2,5
+
+    <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>planningCadastre</gmd:MD_TopicCategoryCode>
+    </gmd:topicCategory>
+    <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>planningCadastre_Planning</gmd:MD_TopicCategoryCode>
+    </gmd:topicCategory>

--- a/source/content/glossar/bibliothek/geocat-examples/dataset-title.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/dataset-title.rst
@@ -1,0 +1,34 @@
+.. code-block:: xml
+   :caption: Example of getting ``dct:title``. Only four languages are taken: DE, EN, FR, IT.
+   :emphasize-lines: 6, 11, 16, 21
+
+   <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+     <gco:CharacterString>Lärmbelastung durch Eisenbahnverkehr (Lr_Nacht)</gco:CharacterString>
+     <gmd:PT_FreeText>
+       <gmd:textGroup>
+         <gmd:LocalisedCharacterString locale="#FR">
+           Exposition au bruit du trafic ferroviaire (Lr_nuit)
+         </gmd:LocalisedCharacterString>
+       </gmd:textGroup>
+       <gmd:textGroup>
+         <gmd:LocalisedCharacterString locale="#DE">
+           Lärmbelastung durch Eisenbahnverkehr (Lr_Nacht)
+         </gmd:LocalisedCharacterString>
+       </gmd:textGroup>
+       <gmd:textGroup>
+         <gmd:LocalisedCharacterString locale="#EN">
+           Nighttime railway noise exposure
+         </gmd:LocalisedCharacterString>
+       </gmd:textGroup>
+       <gmd:textGroup>
+         <gmd:LocalisedCharacterString locale="#IT">
+           Esposizione al rumore del traffico ferroviario (Lr_notte)
+         </gmd:LocalisedCharacterString>
+       </gmd:textGroup>
+       <gmd:textGroup>
+         <gmd:LocalisedCharacterString locale="#RM">
+           Grevezza da canera tras il traffic da viafier durant la notg
+         </gmd:LocalisedCharacterString>
+       </gmd:textGroup>
+     </gmd:PT_FreeText>
+   </gmd:title>

--- a/source/content/glossar/bibliothek/geocat-examples/distribution-access-url.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/distribution-access-url.rst
@@ -1,0 +1,34 @@
+.. code-block:: xml
+    :caption: Example of mapping to the ``dcat:accessURL`` for a distribution of protocol "LINKED:DATA"
+    :emphasize-lines: 3,19,20,21
+
+     <gmd:CI_OnlineResource>
+        <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+            <gmd:URL>https://ld.geo.admin.ch/data/swissBOUNDARIES3D</gmd:URL>
+            <che:PT_FreeURL>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://ld.geo.admin.ch/data/swissBOUNDARIES3D</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">https://ld.geo.admin.ch/data/swissBOUNDARIES3D</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">https://ld.geo.admin.ch/data/swissBOUNDARIES3D</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">https://ld.geo.admin.ch/data/swissBOUNDARIES3D</che:LocalisedURL>
+                </che:URLGroup>
+            </che:PT_FreeURL>
+        </gmd:linkage>
+        <gmd:protocol>
+            <gco:CharacterString>LINKED:DATA</gco:CharacterString>
+        </gmd:protocol>
+        <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>LD</gco:CharacterString>
+            <gmd:PT_FreeText>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">LD</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+            </gmd:PT_FreeText>
+        </gmd:name>
+     </gmd:CI_OnlineResource>

--- a/source/content/glossar/bibliothek/geocat-examples/distribution-description.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/distribution-description.rst
@@ -1,0 +1,31 @@
+.. code-block:: xml
+    :caption: Example of getting ``dct:description`` for ``dcat:Distribution`` from a geocat distribution
+    :emphasize-lines: 18-26
+
+    <gmd:CI_OnlineResource>
+        <gmd:linkage>
+            <gmd:URL>https://map.geo.admin.ch/?layers=ch.bfe.energiestaedte
+            </gmd:URL>
+        </gmd:linkage>
+        <gmd:protocol>
+            <gco:CharacterString>MAP:Preview</gco:CharacterString>
+        </gmd:protocol>
+        <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Map Preview</gco:CharacterString>
+            <gmd:PT_FreeText>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Map Preview
+                    </gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+            </gmd:PT_FreeText>
+        </gmd:name>
+        <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>map preview</gco:CharacterString>
+            <gmd:PT_FreeText>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">map preview
+                    </gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+            </gmd:PT_FreeText>
+        </gmd:description>
+    </gmd:CI_OnlineResource>

--- a/source/content/glossar/bibliothek/geocat-examples/distribution-download-url.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/distribution-download-url.rst
@@ -1,0 +1,42 @@
+.. code-block:: xml
+    :caption: Example of mapping to ``dcat:downloadURL`` for a Distribution with protocol "WWW:DOWNLOAD:INTERLIS"
+    :emphasize-lines: 3,19,20,21
+
+    <gmd:CI_OnlineResource>
+        <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+            <gmd:URL>https://data.geo.admin.ch</gmd:URL>
+            <che:PT_FreeURL>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://data.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">https://data.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">https://data.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">https://data.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+            </che:PT_FreeURL>
+        </gmd:linkage>
+        <gmd:protocol>
+            <gco:CharacterString>WWW:DOWNLOAD:INTERLIS</gco:CharacterString>
+        </gmd:protocol>
+        <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Datenbezug über data.geo.admin</gco:CharacterString>
+            <gmd:PT_FreeText>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Datenbezug über data.geo.admin</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+            </gmd:PT_FreeText>
+        </gmd:name>
+        <gmd:description gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString/>
+        </gmd:description>
+        <gmd:function>
+            <gmd:CI_OnLineFunctionCode
+                codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode"
+                codeListValue="download"/>
+        </gmd:function>
+    </gmd:CI_OnlineResource>

--- a/source/content/glossar/bibliothek/geocat-examples/distribution-language.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/distribution-language.rst
@@ -1,0 +1,50 @@
+.. code-block:: xml
+    :caption: Example of mapping to ``dct:language`` for a Distribution with protocol ``OGC:WMS``
+    :emphasize-lines: 6,9
+
+     <gmd:CI_OnlineResource>
+        <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+            <gmd:URL>http://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de</gmd:URL>
+            <che:PT_FreeURL>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de</che:LocalisedURL>
+                </che:URLGroup>
+            </che:PT_FreeURL>
+        </gmd:linkage>
+        <gmd:protocol>
+            <gco:CharacterString>OGC:WMS</gco:CharacterString>
+        </gmd:protocol>
+        <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>ch.swisstopo:vd.spannungsarme:gebiete</gco:CharacterString>
+            <gmd:PT_FreeText>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">ch.swisstopo:vd.spannungsarme:gebiete
+                    </gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">ch.swisstopo:vd.spannungsarme:gebiete
+                    </gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+            </gmd:PT_FreeText>
+        </gmd:name>
+        <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Service WMS de geo.admin.ch</gco:CharacterString>
+            <gmd:PT_FreeText>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Service WMS de geo.admin.ch</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">WMS Dienst von geo.admin.ch</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#IT">Servizio WMS di geo.admin.ch</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">WMS Service from geo.admin.ch</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+            </gmd:PT_FreeText>
+        </gmd:description>
+     </gmd:CI_OnlineResource>

--- a/source/content/glossar/bibliothek/geocat-examples/distribution-media-type.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/distribution-media-type.rst
@@ -1,0 +1,42 @@
+.. code-block:: xml
+    :caption: Example of mapping to ``dcat:mediaType`` for a Distribution with protocol "WWW:DOWNLOAD:INTERLIS"
+    :emphasize-lines: 20
+
+    <gmd:CI_OnlineResource>
+        <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+            <gmd:URL>https://data.geo.admin.ch</gmd:URL>
+            <che:PT_FreeURL>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://data.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">https://data.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">https://data.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">https://data.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+            </che:PT_FreeURL>
+        </gmd:linkage>
+        <gmd:protocol>
+            <gco:CharacterString>WWW:DOWNLOAD:INTERLIS</gco:CharacterString>
+        </gmd:protocol>
+        <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Datenbezug über data.geo.admin</gco:CharacterString>
+            <gmd:PT_FreeText>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Datenbezug über data.geo.admin</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+            </gmd:PT_FreeText>
+        </gmd:name>
+        <gmd:description gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString/>
+        </gmd:description>
+        <gmd:function>
+            <gmd:CI_OnLineFunctionCode
+                codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode"
+                codeListValue="download"/>
+        </gmd:function>
+    </gmd:CI_OnlineResource>

--- a/source/content/glossar/bibliothek/geocat-examples/distribution-rights.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/distribution-rights.rst
@@ -1,0 +1,34 @@
+.. code-block:: xml
+    :caption: Example of getting rights statements from ``//gmd:resourceConstraints//gmd:otherConstraints``.
+    :emphasize-lines: 7-10,12-14,17-20,23-25
+
+    <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+            <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+                <gmx:Anchor>Opendata BY: Freie Nutzung. Quellenangabe ist Pflicht.</gmx:Anchor>
+                <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">Opendata BY: Freie Nutzung. Quellenangabe
+                            ist Pflicht.
+                        </gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#FR">Opendata BY: Utilisation libre.
+                            Obligation d’indiquer la source.
+                        </gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#IT">Opendata BY: Libero utilizzo. Indicazione
+                            della fonte obbligatoria. Utilizzo a fini commerciali ammesso soltanto previo
+                            consenso del titolare dei dati
+                        </gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                    <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#EN">Opendata BY: Open use. Must provide the
+                            source.
+                        </gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                </gmd:PT_FreeText>
+            </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+    </gmd:resourceConstraints>

--- a/source/content/glossar/bibliothek/geocat-examples/distribution-title.rst
+++ b/source/content/glossar/bibliothek/geocat-examples/distribution-title.rst
@@ -1,0 +1,35 @@
+.. code-block:: xml
+    :caption: Example of mapping to ``dcat:mediaType`` for a Distribution with protocol ``OGC:WFS``
+              The derived title is "OGC:WFS (GetCapabilities) DE#WFS"
+    :emphasize-lines: 19-21,26
+
+     <gmd:CI_OnlineResource>
+        <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+            <gmd:URL>http://wfs.geo.admin.ch</gmd:URL>
+            <che:PT_FreeURL>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://wfs.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://wfs.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">http://wfs.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+                <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">http://wfs.geo.admin.ch</che:LocalisedURL>
+                </che:URLGroup>
+            </che:PT_FreeURL>
+        </gmd:linkage>
+        <gmd:protocol>
+            <gco:CharacterString>OGC:WFS</gco:CharacterString>
+        </gmd:protocol>
+        <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>DE#WFS</gco:CharacterString>
+            <gmd:PT_FreeText>
+                <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">DE#WFS</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+            </gmd:PT_FreeText>
+        </gmd:name>
+     </gmd:CI_OnlineResource>


### PR DESCRIPTION
these are examples for how the gm03 xml received from geocat
is mapped onto dcat properties
These will be later integrated in the documentation of the geocat mapping
to DCAT-AP CH