### PR TITLE
add dcat examples

### DIFF
--- a/source/content/glossar/bibliothek/dcat-examples/catalog-class-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/catalog-class-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: A ``dcat:Catalog`` with a URI in RDF
+    :emphasize-lines: 5,8
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#">
+
+      <dcat:Catalog rdf:about="https://swisstopo/catalog-endpoint.rdf">
+        <dcat:dataset rdf:resource="https://swisstopo/123"/>
+        <dcat:dataset rdf:resource="https://swisstopo/345"/>
+      </dcat:Catalog>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/catalog-class-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/catalog-class-ttl.rst
@@ -1,0 +1,9 @@
+.. code-block:: Turtle
+    :caption: A ``dcat:Catalog`` with a URI in Turtle
+    :emphasize-lines: 3,4
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+    <https://swisstopo/catalog-endpoint.rdf>
+      a dcat:Catalog ;
+      dcat:dataset <https://swisstopo/123>, <https://swisstopo/345> .

--- a/source/content/glossar/bibliothek/dcat-examples/catalog-datasets-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/catalog-datasets-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: A ``dcat:Catalog`` containing two datasets in RDF
+    :emphasize-lines: 6,7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#">
+
+      <dcat:Catalog rdf:about="https://swisstopo/catalog-endpoint.rdf">
+        <dcat:dataset rdf:resource="https://swisstopo/123"/>
+        <dcat:dataset rdf:resource="https://swisstopo/345"/>
+      </dcat:Catalog>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/catalog-datasets-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/catalog-datasets-ttl.rst
@@ -1,0 +1,9 @@
+.. code-block:: Turtle
+    :caption: A ``dcat:Catalog`` containing two datasets in Turtle
+    :emphasize-lines: 5
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+    <https://swisstopo/catalog-endpoint.rdf>
+      a dcat:Catalog ;
+      dcat:dataset <https://swisstopo/123>, <https://swisstopo/345> .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-accrual-periodicity-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-accrual-periodicity-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: dataset that is updated on a daily basis
+    :emphasize-lines: 7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dc="http://purl.org/dc/terms/">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dct:accrualPeriodicity rdf:resource="http://purl.org/cld/freq/daily"/>
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-accrual-periodicity-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-accrual-periodicity-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: dataset that is updated on a daily basis
+    :emphasize-lines: 6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://swisstopo/123>
+              a dcat:Dataset ;
+              dcterms:accrualPeriodicity <http://purl.org/cld/freq/daily>  .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-class-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-class-rdf.rst
@@ -1,0 +1,12 @@
+.. code-block:: xml
+    :caption: a ``dcat:Dataset`` with a URI in rdf
+    :emphasize-lines: 5,6
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-class-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-class-ttl.rst
@@ -1,0 +1,8 @@
+.. code-block:: Turtle
+    :caption: a ``dcat:Dataset`` with a URI in Turtle
+    :emphasize-lines: 3,4
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-contact-point-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-contact-point-rdf.rst
@@ -1,0 +1,27 @@
+.. code-block:: xml
+    :caption: ``vcard:Kind`` is a class: choose between ``vcard:Organization`` and ``vcard:Individual``
+    :emphasize-lines: 8,9,10,11,15,16,17,18
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:vcard="http://www.w3.org/2006/vcard/ns#">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dcat:contactPoint>
+          <vcard:Organization>
+            <vcard:fn>Abteilung Lärm BAFU</vcard:fn>
+            <vcard:hasEmail rdf:resource="mailto:noise@bafu.admin.ch"/>
+          </vcard:Organization>
+        </dcat:contactPoint>
+
+        <dcat:contactPoint>
+          <vcard:Individual>
+            <vcard:fn>Sekretariat BAFU</vcard:fn>
+            <vcard:hasEmail rdf:resource="mailto:sekretariat@bafu.admin.ch"/>
+          </vcard:Individual>
+        </dcat:contactPoint>
+
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-contact-point-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-contact-point-ttl.rst
@@ -1,0 +1,18 @@
+.. code-block:: Turtle
+    :caption: ``vcard:Kind`` is a class: choose between ``vcard:Organization`` and ``vcard:Individual``
+    :emphasize-lines: 7,8,9,11,12,13
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+      dcat:contactPoint [
+        a vcard:Organization ;
+        vcard:fn "Abteilung Lärm BAFU" ;
+        vcard:hasEmail <mailto:noise@bafu.admin.ch>
+      ], [
+        a vcard:Individual ;
+        vcard:fn "Sekretariat BAFU" ;
+        vcard:hasEmail <mailto:sekretariat@bafu.admin.ch>
+      ] .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-coverage-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-coverage-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: Coverage can be a date or a location: it does not have to be an isodate, but can be any date format
+    :emphasize-lines: 7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dct="http://purl.org/dc/terms/">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dct:coverage>2021-04-26</dc:coverage>
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-coverage-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-coverage-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: Coverage can be a date or a location: it does not have to be an isodate, but can be any date format
+    :emphasize-lines: 6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+        dct:coverage "2021-04-26" .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-description-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-description-rdf.rst
@@ -1,0 +1,18 @@
+.. code-block:: xml
+    :caption: Description of a dataset using Markdown in RDF
+    :emphasize-lines: 7,8,9,10,11
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dc="http://purl.org/dc/terms/">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dct:description xml:lang="en">#Railway noises at night
+                                      - [read more here](https://swisstopo/railwaynoises.pdf</dct:description>
+        <dct:description xml:lang="de">#Eisenbahnlärm in der Nacht
+                                      - [eine ausführliche Beschreibung finden Sie hier]
+                                        (https://swisstopo/railwaynoises.pdf)</dct:description>
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-description-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-description-ttl.rst
@@ -1,0 +1,14 @@
+.. code-block:: Turtle
+    :caption: Description of a dataset using Markdown in Turtle
+    :emphasize-lines: 6,7,8,9
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+      dct:description """#Railway noises at night
+                               - [read more here](https://swisstopo/railwaynoises.pdf"""@en, """#Eisenbahnlärm in der Nacht
+                               - [eine ausführliche Beschreibung finden Sie hier]
+                                 (https://swisstopo/railwaynoises.pdf)"""@de .
+

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-distribution-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-distribution-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: ``dcat:Distribution`` with URIs in RDF
+    :emphasize-lines: 6,7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dcat:distribution rdf:resource="https://swisstopo/resource/456"/>
+        <dcat:distribution rdf:resource="https://swisstopo/resource/345"/>
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-distribution-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-distribution-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: ``dcat:Distribution`` with URIs in Turtle
+    :emphasize-lines: 5,6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+      dcat:distribution <https://swisstopo/resource/456>,
+                        <https://swisstopo/resource/345> .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-identifier-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-identifier-rdf.rst
@@ -1,0 +1,15 @@
+.. code-block:: xml
+    :caption: The ``dct:identifier`` is made up of the organization slug and an id to uniquely identify the dataset on opendata.swiss
+
+    :emphasize-lines: 7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dc="http://purl.org/dc/terms/">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dct:identifier>123@amt-fur-landestopographie-swisstopo</dct:identifier>
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-identifier-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-identifier-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: The ``dct:identifier`` is made up of the organization slug and an id to uniquely identify the dataset on opendata.swiss
+    :emphasize-lines: 6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+      dct:identifier "123@amt-fur-landestopographie-swisstopo" .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-issued-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-issued-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: The issued date is expected in ISO Format
+    :emphasize-lines: 7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dct="http://purl.org/dc/terms/">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-26T01:00:00Z</dct:issued>
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-issued-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-issued-ttl.rst
@@ -1,0 +1,11 @@
+.. code-block:: Turtle
+    :caption: The issued date is expected in ISO Format
+    :emphasize-lines: 7
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+        dct:issued "2013-04-26T01:00:00Z"^^xsd:dateTime .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-keyword-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-keyword-rdf.rst
@@ -1,0 +1,18 @@
+.. code-block:: xml
+    :caption: Keywords are given as localized strings
+    :emphasize-lines: 7,8,9,10,11
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dc="http://purl.org/dc/terms/">
+
+      <dcat:Dataset rdf:about="https://tierstatistik.identitas.ch/data/fig-dogs-pyr.csv">
+        <dc:keyword xml:lang="de">Hunde</dc:keyword>
+        <dc:keyword xml:lang="de">statistics</dc:keyword>
+        <dc:keyword xml:lang="fr">Chien</dc:keyword>
+        <dc:keyword xml:lang="en">Dogs</dc:keyword>
+        <dc:keyword xml:lang="it">Cani</dc:keyword>
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-keyword-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-keyword-ttl.rst
@@ -1,0 +1,14 @@
+.. code-block:: Turtle
+    :caption: Keywords are given as localized strings
+    :emphasize-lines: 6,7,8,9,10
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://tierstatistik.identitas.ch/data/fig-dogs-pyr.csv>
+      a dcat:Dataset ;
+      dct:keyword "Hunde"@de,
+                  "statistics"@de,
+                  "Chien"@fr,
+                  "Dogs"@en,
+                  "Cani"@it.

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-landing-page-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-landing-page-rdf.rst
@@ -1,0 +1,11 @@
+.. code-block:: xml
+    :caption: The landing page is provided as a string
+    :emphasize-lines: 6
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dcat:landingPage>http://www.bafu.admin.ch/laerm/index.html?lang=de</dcat:landingPage>
+      </dcat:Dataset>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-landing-page-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-landing-page-ttl.rst
@@ -1,0 +1,9 @@
+.. code-block:: Turtle
+    :caption: The landing page is provided as a string
+    :emphasize-lines: 5
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+        dcat:landingPage "http://www.bafu.admin.ch/laerm/index.html?lang=de" .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-language-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-language-rdf.rst
@@ -1,0 +1,15 @@
+.. code-block:: xml
+    :caption: A ``dcat:Dataset`` with multiple ``dct:language`` properties
+    :emphasize-lines: 7,8
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dct="http://purl.org/dc/terms/">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dct:language>de</dct:language>
+        <dct:language>fr</dct:language>
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-language-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-language-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: A ``dcat:Dataset`` with multiple ``dct:language`` properties
+    :emphasize-lines: 6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+      dct:language "de", "fr".

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-modified-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-modified-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: The date of the last modification is expected in ISO Format
+    :emphasize-lines: 7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dct="http://purl.org/dc/terms/">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-26T01:00:00Z</dct:modified>
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-modified-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-modified-ttl.rst
@@ -1,0 +1,11 @@
+.. code-block:: Turtle
+    :caption: The date of the last modification is expected in ISO Format
+    :emphasize-lines: 7
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+        dct:modified "2013-04-26T01:00:00Z"^^xsd:dateTime .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-publisher-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-publisher-rdf.rst
@@ -1,0 +1,21 @@
+.. code-block:: xml
+    :caption: Publisher of a dataset in RDF
+    :emphasize-lines: 8,9,10,11,12
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dc="http://purl.org/dc/terms/"
+             xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dc:publisher>
+          <rdf:Description>
+            <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Description"/>
+            <rdfs:label:>Bundesamt für Landestopografie swisstopo</rdfs:label:>
+          </rdf:Description>
+        </dc:publisher>
+
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-publisher-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-publisher-ttl.rst
@@ -1,0 +1,15 @@
+.. code-block:: Turtle
+    :caption: Publisher of a dataset in Turtle
+    :emphasize-lines: 7,9
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+      dct:publisher [
+         a rdf:Description ;
+         rdfs:label: "Bundesamt für Landestopografie swisstopo"
+      ] .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-relation-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-relation-rdf.rst
@@ -1,0 +1,24 @@
+.. code-block:: xml
+    :caption: ``dct:relation`` values should be of the class ``rdfs:Resource`` or a subclass.
+              They should therefore each have a URI, according to DCAT
+
+    :emphasize-lines: 8,9,10,11,12,13,14
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dct="http://purl.org/dc/terms/"
+             xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dct:relation rdf:resource="http://www.bafu.admin.ch/laerm/index.html"/>
+        <dct:relation rdf:resource="http://www.bafu.admin.ch/legal_info.html"/>
+        <dct:relation>
+          <rdf:Description rdf:about="http://www.bafu.admin.ch/laerm/index.html?lang=de">
+            <rdfs:label>Webseite des BAFU</rdfs:label>
+          </rdf:Description>
+        </dct:relation>
+
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-relation-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-relation-ttl.rst
@@ -1,0 +1,15 @@
+.. code-block:: Turtle
+    :caption: ``dct:relation`` values should be of the class ``rdfs:Resource`` or a subclass.
+              They should therefore each have a URI, according to DCAT
+
+    :emphasize-lines: 7,9
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+      dct:relation <http://www.bafu.admin.ch/laerm/index.html>, <http://www.bafu.admin.ch/legal_info.html>, <http://www.bafu.admin.ch/laerm/index.html?lang=de> .
+
+    <http://www.bafu.admin.ch/laerm/index.html?lang=de> rdfs:label "Webseite des BAFU" .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-see-also-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-see-also-rdf.rst
@@ -1,0 +1,15 @@
+.. code-block:: xml
+    :caption: A ``dcat:Dataset`` with a ``rdfs:seeAlso`` in RDF
+    :emphasize-lines: 8
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dct="http://purl.org/dc/terms/"
+             xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+         <rdfs:seeAlso>326@swisstopo</rdfs:seeAlso>
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-see-also-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-see-also-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: A ``dcat:Dataset`` with a ``rdfs:seeAlso`` in Turtle
+    :emphasize-lines: 6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+      rdfs:seeAlso "326@swisstopo" .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-spatial-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-spatial-rdf.rst
@@ -1,0 +1,16 @@
+.. code-block:: xml
+    :caption: Property spatial
+    :emphasize-lines: 7,8
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+             xmlns:dct="http://purl.org/dc/terms/">
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+            <dct:spatial rdf:resource="http://publications.europa.eu/mdr/authority/country/ZWE"/>
+            <dct:spatial>Bern</dct:spatial>
+
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-spatial-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-spatial-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: Property spatial
+    :emphasize-lines: 6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+      dct:spatial <http://publications.europa.eu/mdr/authority/country/ZWE>, "Bern" .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-temporal-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-temporal-rdf.rst
@@ -1,0 +1,21 @@
+.. code-block:: xml
+    :caption: A time period in RDF: there can be multiple of these
+    :emphasize-lines: 2,3
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dc="http://purl.org/dc/terms/"
+             xmlns:schema="http://schema.org/">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dc:temporal>
+          <dc:PeriodOfTime>
+            <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1905-03-01</schema:startDate>
+            <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2013-01-05</schema:endDate>
+          </dc:PeriodOfTime>
+        </dc:temporal>
+
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-temporal-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-temporal-ttl.rst
@@ -1,0 +1,16 @@
+.. code-block:: Turtle
+    :caption: A time period in Turtle: there can be multiple of these
+    :emphasize-lines: 8,9,10,11,12
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix schema: <http://schema.org/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+      dct:temporal [
+        a dct:PeriodOfTime ;
+        schema:startDate "1905-03-01"^^xsd:date ;
+        schema:endDate "2013-01-05"^^xsd:date
+      ] .

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-theme-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-theme-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: The categories are selected from a Swiss controlled vocabulary
+    :emphasize-lines: 6,7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#">
+
+      <dcat:Dataset rdf:about="https://swisstopo/123">
+        <dcat:theme rdf:resource="http://opendata.swiss/themes/population"/>
+        <dcat:theme rdf:resource="http://opendata.swiss/themes/territory"/>
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-theme-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-theme-ttl.rst
@@ -1,0 +1,11 @@
+.. code-block:: Turtle
+    :caption: The categories are selected from a Swiss controlled vocabulary
+    :emphasize-lines: 6,7
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://swisstopo/123>
+      a dcat:Dataset ;
+      dcat:theme <http://opendata.swiss/themes/population>,
+                 <http://opendata.swiss/themes/territory> ;

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-title-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-title-rdf.rst
@@ -1,0 +1,17 @@
+.. code-block:: xml
+    :caption: In RDF the language is stored in the ``xml:lang`` attribute
+    :emphasize-lines: 7,8,9,10
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dc="http://purl.org/dc/terms/">
+
+      <dcat:Dataset rdf:about="https://tierstatistik.identitas.ch/data/fig-dogs-pyr.csv">
+        <dct:title xml:lang="de">Hunde</dct:title>
+        <dct:title xml:lang="fr">Chien</dct:title>
+        <dct:title xml:lang="en">Dogs</dct:title>
+        <dct:title xml:lang="it">Cani</dct:title>
+      </dcat:Dataset>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/dataset-title-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/dataset-title-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: In Turtle strings are marked by the language they are in
+    :emphasize-lines: 6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://tierstatistik.identitas.ch/data/fig-dogs-pyr.csv>
+      a dcat:Dataset ;
+      dct:title "Hunde"@de, "Chien"@fr, "Dogs"@en, "Cani"@it.

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-access-url-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-access-url-rdf.rst
@@ -1,0 +1,13 @@
+.. code-block:: xml
+    :caption: The access url is mandatory
+    :emphasize-lines: 6
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#">
+
+      <dcat:Distribution rdf:about="http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg">
+        <dcat:accessURL rdf:resource="http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg"/>
+      </dcat:Distribution>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-access-url-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-access-url-ttl.rst
@@ -1,0 +1,11 @@
+.. code-block:: Turtle
+    :caption: The access url is mandatory
+    :emphasize-lines: 7
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg>
+       a dcat:Distribution ;
+       dcat:accessURL <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg> .

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-byte-size-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-byte-size-rdf.rst
@@ -1,0 +1,13 @@
+.. code-block:: xml
+    :caption: The size in bytes of a distribution is given as a decimal
+    :emphasize-lines: 6
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#">
+
+      <dcat:Distribution rdf:about="https://swisstopo/123">
+        <dcat:byteSize rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">698039.0</dcat:byteSize>
+      </dcat:Distribution>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-byte-size-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-byte-size-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: The size in bytes of a distribution is given as a decimal
+    :emphasize-lines: 6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <https://swisstopo/123>
+      a dcat:Distribution ;
+        dcat:byteSize "698039"^^xsd:decimal .

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-class-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-class-rdf.rst
@@ -1,0 +1,12 @@
+.. code-block:: xml
+    :caption: a ``dcat:Distribution`` with a URI
+    :emphasize-lines: 5,6
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#">
+
+      <dcat:Distribution rdf:about="https://swisstopo/123/file.csv">
+      </dcat:Distribution>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-class-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-class-ttl.rst
@@ -1,0 +1,8 @@
+.. code-block:: Turtle
+    :caption: a ``dcat:Distribution`` with a URI
+    :emphasize-lines: 3,4
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+    <https://swisstopo/123/file.csv>
+      a dcat:Distribution .

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-coverage-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-coverage-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: Coverage can be a date or a location: it does not have to be an isodate, but can be any date format
+    :emphasize-lines: 7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dct="http://purl.org/dc/terms/">
+
+      <dcat:Distribution rdf:about="https://swisstopo/distribution/1235">
+        <dct:coverage>2021-04-26</dc:coverage>
+      </dcat:Distribution>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-coverage-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-coverage-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: Coverage can be a date or a location: it does not have to be an isodate, but can be any date format
+    :emphasize-lines: 6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://swisstopo/distribution/1235>
+      a dcat:Distribution ;
+        dct:coverage "2021-04-26" .

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-description-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-description-rdf.rst
@@ -1,0 +1,15 @@
+.. code-block:: xml
+    :caption: Description of a distribution in RDF
+    :emphasize-lines: 7,8
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dc="http://purl.org/dc/terms/">
+
+      <dcat:Distribution rdf:about="https://swisstopo/123456">
+        <dc:description xml:lang="en">Railway noises at night</dc:description>
+        <dc:description xml:lang="de">Eisenbahnlärm in der Nacht</dc:description>
+      </dcat:Distribution>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-description-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-description-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: Description of a distribution in Turtle
+    :emphasize-lines: 6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://swisstopo/123456>
+      a dcat:Distribution ;
+      dct:description "Railway noises at night"@en, "Eisenbahnlärm in der Nacht"@de .

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-download-url-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-download-url-rdf.rst
@@ -1,0 +1,13 @@
+.. code-block:: xml
+    :caption: The download url can be used for files
+    :emphasize-lines: 6
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#">
+
+      <dcat:Distribution rdf:about="https://swisstopo/123">
+        <dcat:downloadURL rdf:resource="http:swisstopo/file/1234/ld+json"/>
+        <dcat:accessURL rdf:resource="http:swisstopo/file/1234/ld+json"/>
+        <dcat:mediaType: rdf:resource="https://www.iana.org/assignments/media-types/application/ld+json"/>
+      </dcat:Distribution>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-download-url-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-download-url-ttl.rst
@@ -1,0 +1,13 @@
+.. code-block:: Turtle
+    :caption: The download url can be used for files and will then be the same as the access url
+    :emphasize-lines: 7
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <https://swisstopo/123>
+      a dcat:Distribution ;
+          dcat:downloadURL <http:swisstopo/file/1234/ld+json> ;
+          dcat:accessURL <http:swisstopo/file/1234/ld+json> ;
+          dcat:mediaType: <https://www.iana.org/assignments/media-types/application/ld+json> .

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-format-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-format-rdf.rst
@@ -1,0 +1,15 @@
+.. code-block:: xml
+    :caption: The format is used for distributions that have no download url
+    :emphasize-lines: 8
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dc="http://purl.org/dc/terms/">
+
+      <dcat:Distribution rdf:about="http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg">
+        <dcat:accessURL rdf:resource="http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg"/>
+        <dc:format rdf:resource="https://www.iana.org/assignments/media-types/img/jpeg"/>
+      </dcat:Distribution>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-format-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-format-ttl.rst
@@ -1,0 +1,12 @@
+.. code-block:: Turtle
+    :caption: The format is used for distributions that have no download url
+    :emphasize-lines: 8
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg>
+       a dcat:Distribution ;
+       dcat:accessURL <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg> ;
+       dct:format  <https://www.iana.org/assignments/media-types/img/jpeg> .

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-identifier-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-identifier-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: A ``dcat:Distribution`` with a ``dct:identifier`` in RDF
+    :emphasize-lines: 7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+           xmlns:dcat="http://www.w3.org/ns/dcat#"
+           xmlns:dc="http://purl.org/dc/terms/">
+
+      <dcat:Distribution rdf:about="https://swisstopo/123567">
+        <dct:identifier>ch.bafu.laerm-bahnlaerm_nacht</dct:identifier>
+      </dcat:Distribution>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-identifier-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-identifier-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: A ``dcat:Distribution`` with a ``dct:identifier`` in RDF
+    :emphasize-lines: 6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://swisstopo/123567>
+      a dcat:Distribution ;
+      dct:identifier "ch.bafu.laerm-bahnlaerm_nacht" .

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-issued-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-issued-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: The issued date is expected in ISO Format
+    :emphasize-lines: 7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dc="http://purl.org/dc/terms/">
+
+      <dcat:Distribution rdf:about="https://swisstopo/123">
+        <dc:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-26T01:00:00Z</dc:issued>
+      </dcat:Distribution>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-issued-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-issued-ttl.rst
@@ -1,0 +1,11 @@
+.. code-block:: Turtle
+    :caption: The issued date is expected in ISO Format
+    :emphasize-lines: 7
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <https://swisstopo/123>
+      a dcat:Distribution ;
+        dct:issued "2013-04-26T01:00:00Z"^^xsd:dateTime .

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-language-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-language-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: The language of a distribution
+    :emphasize-lines: 7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dc="http://purl.org/dc/terms/">
+
+      <dcat:Distribution rdf:about="https://swisstopo/123">
+        <dc:language>fr</dc:language>
+      </dcat:Distribution>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-language-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-language-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: The language of a distribution
+    :emphasize-lines: 6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://swisstopo/123>
+      a dcat:Distribution ;
+      dct:language "fr".

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-media-type-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-media-type-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: The mediaType is used to specify the file format of a download url
+    :emphasize-lines: 7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#">
+
+      <dcat:Distribution rdf:about="https://swisstopo/123">
+        <dcat:downloadURL rdf:resource="http:swisstopo/file/1234/ld+json"/>
+        <dcat:mediaType rdf:resource="https://www.iana.org/assignments/media-types/application/ld+json"/>
+      </dcat:Distribution>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-media-type-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-media-type-ttl.rst
@@ -1,0 +1,12 @@
+.. code-block:: Turtle
+    :caption: The mediaType is used to specify the file format of a download url
+    :emphasize-lines: 8
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <https://swisstopo/123>
+      a dcat:Distribution ;
+          dcat:downloadURL <http:swisstopo/file/1234/ld+json> ;
+          dcat:mediaType <https://www.iana.org/assignments/media-types/application/ld+json> .

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-modified-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-modified-rdf.rst
@@ -1,0 +1,14 @@
+.. code-block:: xml
+    :caption: The modified date is expected in ISO Format
+    :emphasize-lines: 7
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dc="http://purl.org/dc/terms/">
+
+      <dcat:Distribution rdf:about="https://swisstopo/123">
+        <dc:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2013-04-26T01:00:00Z</dc:modified>
+      </dcat:Distribution>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-modified-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-modified-ttl.rst
@@ -1,0 +1,11 @@
+.. code-block:: Turtle
+        :caption: The modified date is expected in ISO Format
+        :emphasize-lines: 7
+
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix dct: <http://purl.org/dc/terms/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        <https://swisstopo/123>
+          a dcat:Distribution ;
+            dct:modified "2013-04-26T01:00:00Z"^^xsd:dateTime .

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-rights-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-rights-rdf.rst
@@ -1,0 +1,15 @@
+.. code-block:: xml
+    :caption: the rights statement comes from a controlled vocabulary
+    :emphasize-lines: 8
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dcat="http://www.w3.org/ns/dcat#"
+             xmlns:dct="http://purl.org/dc/terms/">
+
+      <dcat:Distribution rdf:about="http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg">
+        <dcat:accessURL rdf:resource="http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg"/>
+        <dct:rights>NonCommercialAllowed-CommercialAllowed-ReferenceRequired</dct:rights>
+      </dcat:Distribution>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-rights-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-rights-ttl.rst
@@ -1,0 +1,12 @@
+.. code-block:: Turtle
+    :caption: the rights statement comes from a controlled vocabulary
+    :emphasize-lines: 8
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg>
+       a dcat:Distribution ;
+       dcat:accessURL <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg> ;
+       dct:rights "NonCommercialAllowed-CommercialAllowed-ReferenceRequired" .

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-title-rdf.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-title-rdf.rst
@@ -1,0 +1,17 @@
+.. code-block:: xml
+    :caption: In RDF the language is stored in the ``xml:lang`` attribute
+    :emphasize-lines: 7,8,9,10
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+           xmlns:dcat="http://www.w3.org/ns/dcat#"
+           xmlns:dc="http://purl.org/dc/terms/">
+
+       <dcat:Distribution rdf:about="https://tierstatistik.identitas.ch/data/fig-dogs-pyr.csv">
+          <dc:title xml:lang="de">Hunde</dc:title>
+          <dc:title xml:lang="fr">Chien</dc:title>
+          <dc:title xml:lang="en">Dogs</dc:title>
+          <dc:title xml:lang="it">Cani</dc:title>
+       </dcat:Distribution>
+
+    </rdf:RDF>

--- a/source/content/glossar/bibliothek/dcat-examples/distribution-title-ttl.rst
+++ b/source/content/glossar/bibliothek/dcat-examples/distribution-title-ttl.rst
@@ -1,0 +1,10 @@
+.. code-block:: Turtle
+    :caption: In Turtle strings are marked by the language they are in
+    :emphasize-lines: 6
+
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+
+    <https://tierstatistik.identitas.ch/data/fig-dogs-pyr.csv>
+      a dcat:Distribution ;
+      dct:title "Hunde"@de, "Chien"@fr, "Dogs"@en, "Cani"@it.


### PR DESCRIPTION
these are example for how to build an rdf catalog in DCAT-AP CH standard
the examples are per property
they will be added to the documentation later on