### PR TITLE
feat: Run Gitlab Sync action in 'test' environment

### DIFF
--- a/.github/workflows/gitlab-sync.yml
+++ b/.github/workflows/gitlab-sync.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: test
     steps:
       - uses: actions/checkout@v1
       - name: Mirror + trigger CI


### PR DESCRIPTION
Otherwise we don't have access to the gitlab credentials that are saved in the test environment of this repo.