### PR TITLE
fix: Upgrade babel to the latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alabaster==0.7.12
-Babel==2.9.1
+Babel==2.14.0
 certifi==2023.7.22
 charset-normalizer==2.0.7
 click==8.0.3


### PR DESCRIPTION
The cgi module was removed in Python 3.8 and it looks like  Babel 2.9.1 may still rely on the cgi module