### PR TITLE
fix: organisation uri and invalid syntax for long description in publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -2,7 +2,6 @@ publiccodeYmlVersion: 0.5.0
 name: ogdch-handbook
 url: https://github.com/opendata-swiss/ogdch-handbook
 releaseDate: 2021-02-21
-logo: https://opendata.swiss/images/logo_horizontal.png
 platforms:
   - web
 categories:

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -8,7 +8,8 @@ platforms:
 categories:
   - other
 organisation:
-  uri: https://opendata.swiss
+  uri: https://ld.admin.ch/office/II.1.7
+  name: Federal Statistical Office (FSO)
 usedBy:
   - Swiss Federal Statistical Office
 developmentStatus: stable
@@ -21,9 +22,11 @@ description:
   en:
     localisedName: Handbook opendata.swiss
     shortDescription: Handbook provides documentation and guidelines to publish and consume data on opendata.swiss
-    longDescription: [Handbook](https://handbook.opendata.swiss) for opendata.swiss serves as documentation and provides guidelines for data publishers in 
-      the process of publishing their data on opendata.swiss. Data users can find instructions on how to search for data
-      efficiently and how to make use of the data via API.
+    longDescription: >
+      The handbook for opendata.swiss (https://handbook.opendata.swiss) serves as documentation and
+      provides guidelines for data publishers in the process of publishing their data on opendata.swiss.
+      Data users can find instructions on how to search for data efficiently and how to make use of the
+      data via API.
     features:
       - provide guidance for publishing data on opendata.swiss
       - support data users to search for data on opendata.swiss


### PR DESCRIPTION
We noticed that there are some errors in your publiccode.yml file that prevents your software to show up on https://opensource.admin.ch

- the publiccode.yml parser checks the validity of the logo url and checks if it is reachable. Unfortunatly to underlying go library uses `Go-http-client/1.1`  as the user agent. This causes the request to be blocked by the Web Application Firewall. The only workaround for now is to remove the logo url (we are not in control of the validator)

- Organisations must be one of the options given in https://swiss.github.io/publiccode-editor/ - this means it must be one of https://ld.admin.ch/office
Otherwise it won't be mapped to the correct organisational unit from the dropdown filter.

- markdown is not supported yet, and the opening bracket you used for `longDescription? confused the yaml parser.

You can upload your publiccode.yml file to the editor and validate the content there: https://swiss.github.io/publiccode-editor/ 
But this won't catch errors like the unreachable logo url.
We hope that we will be able to improve on the underlying ecosystem - but for now this PR should do the trick and it's all I can contribute at the moment.